### PR TITLE
Centralize styling in shared stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,25 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>KELLE BEÝNINIŇ MRT BARLAGY</title>
     <link rel="stylesheet" href="styles.css" />
-  <style>
-    body {
-      font-family: Arial, sans-serif;
-      line-height: 1.6;
-      margin: 20px;
-    }
-    h1, h2 {
-      color: #333;
-    }
-    p {
-      margin-bottom: 1em;
-    }
-    .header, .section {
-      margin-bottom: 20px;
-    }
-    .label {
-      font-weight: bold;
-    }
-  </style>
     <!-- Removed JSZip reference -->
     <script src="https://cdn.jsdelivr.net/npm/docxtemplater@3.42.0/build/docxtemplater.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
@@ -43,9 +24,9 @@
       <div class="protocol">
         <h1>KELLE BEÝNINIŇ MRT BARLAGY</h1>
  
-<form id="research-form" style="display:inline-flex; align-items:center; gap:6px; font-size:14px;">
+<form id="research-form">
   <label for="research-date">Barlagyň senesi:</label>
-  <input type="date" id="research-date" name="research-date"  style="padding:0px;">
+  <input type="date" id="research-date" name="research-date">
 </form>
 <script>
   document.getElementById('research-date').value = new Date().toISOString().split('T')[0];

--- a/styles.css
+++ b/styles.css
@@ -2,12 +2,40 @@ body {
     font-family: Arial, sans-serif;
     background: linear-gradient(to right, #6a11cb, #2575fc);
     margin: 0;
-    padding: 0;
-    height: 100%;
+    padding: 20px;
+    min-height: 100vh;
     display: flex;
-    justify-content: center;
+    flex-direction: column;
     align-items: center;
-    color: #000000;
+    justify-content: flex-start;
+    box-sizing: border-box;
+    line-height: 1.6;
+    color: #333;
+}
+
+h1,
+h2 {
+    color: #333;
+}
+
+p {
+    margin: 0 0 1em;
+}
+
+.header,
+.section,
+.container {
+    width: 100%;
+    max-width: 800px;
+}
+
+.header,
+.section {
+    margin-bottom: 20px;
+}
+
+.label {
+    font-weight: bold;
 }
 
 .container {
@@ -25,6 +53,19 @@ h2 {
     color: #333;
     font-size: 24px;
     margin-bottom: 20px;
+}
+
+#research-form {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 14px;
+    margin: 10px 0 20px;
+}
+
+#research-form input[type="date"] {
+    width: auto;
+    padding: 6px 8px;
 }
 
 label {


### PR DESCRIPTION
## Summary
- move base typography, spacing, and label styles from inline definitions into styles.css
- align header and content blocks with a unified container width and flex positioning
- style the research date form inline with the shared layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692405976d7c83298d4dccb54f4c156c)