### PR TITLE
Align MRI form fields and scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>KELLE BEÝNINIŇ MRT BARLAGY</title>
     <link rel="stylesheet" href="styles.css" />
-    <!-- Removed JSZip reference -->
+    <script src="https://cdn.jsdelivr.net/npm/pizzip@3.1.6/dist/pizzip.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/docxtemplater@3.42.0/build/docxtemplater.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
     <!-- Порядок важен: сначала Pizzip, потом docxtemplater -->
@@ -23,93 +23,157 @@
    <div class="container">
       <div class="protocol">
         <h1>KELLE BEÝNINIŇ MRT BARLAGY</h1>
- 
-<form id="research-form">
-  <label for="research-date">Barlagyň senesi:</label>
-  <input type="date" id="research-date" name="research-date">
-</form>
-<script>
-  document.getElementById('research-date').value = new Date().toISOString().split('T')[0];
-</script>
-           <p>Barlag:
-            <select id="research-type-1">
-              <option value="Первичное">Ilkinji gezek.</option>
-              <option value="Повторное">
-                Gaýtadan.
-              </option>
-            </select>
-           
-        Artefaktlar:
-            <select id="research-type-2">
-              <option value="Без артефактов.">Artefaktlar ýok.</option>
-              <option value="Артефакты от движения пациента.">
-                Näsagyň hereket artefaktlary.
-              </option>
-              <option value="Артефакты от металлических объектов.">
-                Metal artefaktlar.
-              </option>
-            </select>
-           </span>
-             </p>
-        <h2>Barlag protokoly:</h2>
-        <p><strong>Kelle çanak:</strong>
-          <select id="research-type">
-          <option value="Мезоцефалическая.">Mezosefal tipli.</option>
-          <option value="Долихоцефалическая.">Dolihosefal tipli.</option>
-          <option value="Брахиоцефалическая">Brahiosefal tipli.</option>
-        </select>
-        Tikinlri:<select id="research-type">
-            <option value="Без признаков краниостеноза.">
-                kadaly ýagdaýda.
-              </option>
-            <option value="Признаки краниостеноза.">
-            kraniostenoz alamatlary.
-          </option>
-        </select>
-        Simmetriýa:<select id="research-type">
-          <option value="Симметричная.">simmetrik.</option>
-          <option value="Асимметричная.">Asimmetrik.</option>
-        </select>
 
-        Kelleçanagyň çukurjuklary:<select id="research-type">
-          <option value="Нормальные.">kadaly.</option>
-          <option value="Тесные.">gysylan.</option>
-          <option value="Расширены.">giňelen.</option>
-        </select>
+        <form id="research-form">
+          <div class="form-grid">
+            <div class="field-group">
+              <label for="research-date">Barlagyň senesi:</label>
+              <input type="date" id="research-date" name="research-date" required />
+            </div>
+            <div class="field-group">
+              <label for="patient-name">Familiyasy, ady:</label>
+              <input type="text" id="patient-name" name="patient-name" required />
+            </div>
+            <div class="field-group">
+              <label for="department">Bölüm:</label>
+              <input type="text" id="department" name="department" required />
+            </div>
+            <div class="field-group">
+              <span class="field-label">Jynsy:</span>
+              <div class="option-row">
+                <label><input type="radio" id="gender-male" name="gender" value="Erkek" required /> Erkek</label>
+                <label><input type="radio" id="gender-female" name="gender" value="Aýal" /> Aýal</label>
+              </div>
+            </div>
+            <div class="field-group">
+              <label for="birth-year">Doglan ýyly:</label>
+              <input type="number" id="birth-year" name="birth-year" min="1900" max="2100" required />
+            </div>
+            <div class="field-group">
+              <label for="patient-code">Näsagyň kody:</label>
+              <input type="text" id="patient-code" name="patient-code" />
+            </div>
+            <div class="field-group">
+              <span class="field-label">Barlag usuly:</span>
+              <div class="option-column">
+                <label><input type="checkbox" id="method-t1" name="method" value="T1" /> T1</label>
+                <label><input type="checkbox" id="method-t2" name="method" value="T2" /> T2</label>
+                <label><input type="checkbox" id="method-fla" name="method" value="FLAIR" /> FLAIR</label>
+              </div>
+            </div>
+            <div class="field-group">
+              <label for="research-frequency">Barlag:</label>
+              <select id="research-frequency" name="research-frequency">
+                <option value="Ilkinji gezek.">Ilkinji gezek.</option>
+                <option value="Gaýtadan.">Gaýtadan.</option>
+              </select>
+            </div>
+            <div class="field-group">
+              <label for="artifact-notes">Artefaktlar:</label>
+              <select id="artifact-notes" name="artifact-notes">
+                <option value="Artefaktlar ýok.">Artefaktlar ýok.</option>
+                <option value="Näsagyň hereket artefaktlary.">Näsagyň hereket artefaktlary.</option>
+                <option value="Metal artefaktlar.">Metal artefaktlar.</option>
+              </select>
+            </div>
+          </div>
 
-        Operasiýadan soňky üýtgemeleri:
-        <select id="postoperative-changes">
-          <option value="Отсутствуют.">ýok.</option>
-          <option value="Краниотомия.">Kraniotomiýa.</option>
-        </select> </p>
+          <h2>Barlag protokoly:</h2>
+          <div class="field-group">
+            <label for="skull-shape"><strong>Kelle çanak:</strong></label>
+            <select id="skull-shape" name="skull-shape">
+              <option value="Mezosefal tipli.">Mezosefal tipli.</option>
+              <option value="Dolihosefal tipli.">Dolihosefal tipli.</option>
+              <option value="Brahiosefal tipli.">Brahiosefal tipli.</option>
+            </select>
+          </div>
+          <div class="field-group">
+            <label for="cranial-sutures">Tikinleri:</label>
+            <select id="cranial-sutures" name="cranial-sutures">
+              <option value="kadaly ýagdaýda.">kadaly ýagdaýda.</option>
+              <option value="kraniostenoz alamatlary.">kraniostenoz alamatlary.</option>
+            </select>
+          </div>
+          <div class="field-group">
+            <label for="skull-symmetry">Simmetriýa:</label>
+            <select id="skull-symmetry" name="skull-symmetry">
+              <option value="Simmetrik.">Simmetrik.</option>
+              <option value="Asimmetrik.">Asimmetrik.</option>
+            </select>
+          </div>
+          <div class="field-group">
+            <label for="cranial-fossa">Kelleçanagyň çukurjuklary:</label>
+            <select id="cranial-fossa" name="cranial-fossa">
+              <option value="Kadaly.">Kadaly.</option>
+              <option value="Gysylan.">Gysylan.</option>
+              <option value="Giňelen.">Giňelen.</option>
+            </select>
+          </div>
+          <div class="field-group">
+            <label for="postoperative-changes">Operasiýadan soňky üýtgemeleri:</label>
+            <select id="postoperative-changes" name="postoperative-changes">
+              <option value="ýok.">ýok.</option>
+              <option value="Kraniotomiýa.">Kraniotomiýa.</option>
+            </select>
+          </div>
 
-        <p><strong>Ak we çal maddanyň differensasiýasy: </>
-                  <select id="postoperative-changes">
-              <option value="Отчетливая, без очаговых изменений.">
-                aýdyň. Ojaklaýyn üýtgmeleri bellenmeýär.
-              </option>
-              <option value="Не Отчетливая, с очаговымы изменениями.">
-                ojaklaýyn üýtgemelri anyklanýar.
-              </option>
+          <div class="field-group">
+            <label for="differentiation"><strong>Ak we çal maddanyň differensasiýasy:</strong></label>
+            <select id="differentiation" name="differentiation">
+              <option value="aýdyň. Ojaklaýyn üýtgemeleri bellenmeýär.">aýdyň. Ojaklaýyn üýtgemeleri bellenmeýär.</option>
+              <option value="ojaklaýyn üýtgemelri anyklanýar.">ojaklaýyn üýtgemelri anyklanýar.</option>
             </select>
-        Geterotopiýa:
-            <select id="postoperative-changes">
-              <option value="Отсутствует.">bellenmeýar.</option>
-              <option value="Присутствует.">bellenýär.</option>
+          </div>
+          <div class="field-group">
+            <label for="heterotopia">Geterotopiýa:</label>
+            <select id="heterotopia" name="heterotopia">
+              <option value="bellenmeýar.">bellenmeýar.</option>
+              <option value="bellenýär.">bellenýär.</option>
             </select>
-        Гиппокамп:
-            <select id="postoperative-changes">
-              <option value="Симметричный.">Симметричный.</option>
-              <option value="Асимметричный.">Асимметричный.</option>
+          </div>
+          <div class="field-group">
+            <label for="hippocampus-symmetry">Gippokamp simmetriýasy:</label>
+            <select id="hippocampus-symmetry" name="hippocampus-symmetry">
+              <option value="Simmetrik.">Simmetrik.</option>
+              <option value="Asimmetrik.">Asimmetrik.</option>
             </select>
-            <select id="postoperative-changes">
-              <option value="очаговые изменения нет.">
-                очаговые изменения нет.
-              </option>
-              <option value="очаговые изменения есть.">
-                очаговые изменения есть.
-              </option>
+          </div>
+          <div class="field-group">
+            <label for="hippocampus-lesions">Gippokampdaky ojaklar:</label>
+            <select id="hippocampus-lesions" name="hippocampus-lesions">
+              <option value="ojaklaýyn üýtgeşme ýok.">ojaklaýyn üýtgeşme ýok.</option>
+              <option value="ojaklaýyn üýtgeşme bar.">ojaklaýyn üýtgeşme bar.</option>
             </select>
+          </div>
+
+          <div class="field-group">
+            <label for="parenchyma-changes">Beýni parenhimasynyň ojaklaýyn üýtgemeleri:</label>
+            <textarea id="parenchyma-changes" name="parenchyma-changes" rows="3" placeholder="Degişli bellikler"></textarea>
+          </div>
+          <div class="field-group">
+            <label for="liquor-spaces">Likwor saklaýan giňişlikler:</label>
+            <textarea id="liquor-spaces" name="liquor-spaces" rows="3" placeholder="Degişli bellikler"></textarea>
+          </div>
+          <div class="field-group">
+            <label for="conclusion">Netije:</label>
+            <textarea id="conclusion" name="conclusion" rows="3" required></textarea>
+          </div>
+          <div class="field-group">
+            <label for="advice">Maslahat:</label>
+            <textarea id="advice" name="advice" rows="3" required></textarea>
+          </div>
+          <div class="field-group">
+            <label for="doctor">Lukman:</label>
+            <input type="text" id="doctor" name="doctor" required />
+          </div>
+
+          <div class="form-actions">
+            <button type="submit">Hasabat döret</button>
+            <button type="button" id="saveWord">Word görnüşde ýükle</button>
+          </div>
+        </form>
+
+        <div id="result" class="result" aria-live="polite"></div>
         <h3>2.3. Очаговые изменения</h3>
         <h4>А. Дисциркуляторные очаги</h4>
         <ul>

--- a/saveWord.js
+++ b/saveWord.js
@@ -1,48 +1,58 @@
 document.addEventListener('DOMContentLoaded', function() {
-    document.getElementById('saveWord').addEventListener('click', async function() {
+    const saveButton = document.getElementById('saveWord');
+    if (!saveButton) return;
+
+    saveButton.addEventListener('click', async function() {
         try {
-            // Проверка загрузки библиотек
             if (typeof PizZip === 'undefined' || typeof docxtemplater === 'undefined') {
                 throw new Error("Библиотеки не загружены. Проверьте консоль браузера.");
             }
 
-            // Сбор данных формы
+            const genderInput = document.querySelector('input[name="gender"]:checked');
+            const methods = Array.from(document.querySelectorAll('input[name="method"]:checked')).map(el => el.value).join(', ');
+
             const formData = {
-                date: document.getElementById('date').value,
-                fname: document.getElementById('fname').value,
-                department: document.getElementById('department').value,
-                gender: document.querySelector('input[name="gender"]:checked').value,
-                birthYear: document.getElementById('birthYear').value,
-                code: document.getElementById('code').value,
-                brainImage: document.getElementById('brainImage').value,
-                differentiation: document.getElementById('differentiation').value,
-                changes: document.getElementById('changes').value,
-                liquorSpaces: document.getElementById('liquorSpaces').value,
-                conclusion: document.getElementById('conclusion').value,
-                advice: document.getElementById('advice').value,
-                doctor: document.getElementById('doctor').value,
-                methods: Array.from(document.querySelectorAll('input[name="method"]:checked')).map(el => el.value).join(', '),
-                artifacts: document.querySelector('input[name="artifacts"]:checked')?.value || 'Не указано'
+                date: document.getElementById('research-date')?.value || '',
+                patientName: document.getElementById('patient-name')?.value || '',
+                department: document.getElementById('department')?.value || '',
+                gender: genderInput?.value || '',
+                birthYear: document.getElementById('birth-year')?.value || '',
+                patientCode: document.getElementById('patient-code')?.value || '',
+                methods,
+                researchFrequency: document.getElementById('research-frequency')?.value || '',
+                artifactNotes: document.getElementById('artifact-notes')?.value || '',
+                skullShape: document.getElementById('skull-shape')?.value || '',
+                cranialSutures: document.getElementById('cranial-sutures')?.value || '',
+                skullSymmetry: document.getElementById('skull-symmetry')?.value || '',
+                cranialFossa: document.getElementById('cranial-fossa')?.value || '',
+                postoperativeChanges: document.getElementById('postoperative-changes')?.value || '',
+                differentiation: document.getElementById('differentiation')?.value || '',
+                heterotopia: document.getElementById('heterotopia')?.value || '',
+                hippocampusSymmetry: document.getElementById('hippocampus-symmetry')?.value || '',
+                hippocampusLesions: document.getElementById('hippocampus-lesions')?.value || '',
+                parenchymaChanges: document.getElementById('parenchyma-changes')?.value || '',
+                liquorSpaces: document.getElementById('liquor-spaces')?.value || '',
+                conclusion: document.getElementById('conclusion')?.value || '',
+                advice: document.getElementById('advice')?.value || '',
+                doctor: document.getElementById('doctor')?.value || ''
             };
 
-            // Логирование данных для отладки
             console.log("Form Data:", formData);
 
-            // Загрузка шаблона
             const response = await fetch("template.docx");
             if (!response.ok) throw new Error("Ошибка загрузки шаблона: " + response.status);
-            
+
             const buffer = await response.arrayBuffer();
             const zip = new PizZip(buffer);
-            
+
             const doc = new docxtemplater();
             doc.loadZip(zip);
-            
+
             doc.setData(formData);
-            doc.render(); // Если есть ошибки рендеринга, они появятся здесь
-            
+            doc.render();
+
             const out = doc.getZip().generate({ type: "blob" });
-            saveAs(out, "report_${new Date().toISOString()}.docx");
+            saveAs(out, `report_${new Date().toISOString()}.docx`);
 
         } catch(error) {
             console.error("Ошибка:", error);

--- a/script.js
+++ b/script.js
@@ -1,51 +1,94 @@
 document.addEventListener('DOMContentLoaded', () => {
-    document.querySelector('form').addEventListener('submit', event => {
+    const form = document.getElementById('research-form');
+    const dateInput = document.getElementById('research-date');
+
+    if (dateInput && !dateInput.value) {
+        dateInput.value = new Date().toISOString().split('T')[0];
+    }
+
+    if (!form) return;
+
+    form.addEventListener('submit', event => {
         event.preventDefault();
-        submitForm();
+        renderSummary();
     });
 });
 
-function submitForm() {
-    const date = document.getElementById('date').value;
-    const fname = document.getElementById('fname').value.trim();
-    const department = document.getElementById('department').value.trim();
-    const gender = document.querySelector('input[name="gender"]:checked').value;
-    const birthYear = document.getElementById('birthYear').value;
-    const code = document.getElementById('code').value.trim();
-    const methods = Array.from(document.querySelectorAll('input[name="method"]:checked'))
-                          .map(checkbox => checkbox.value).join(', ');
-    const artifacts = document.querySelector('input[name="artifacts"]:checked') ? 'Ýok' : '';
-    const exam = document.querySelector('input[name="exam"]:checked').value;
-    const brainImage = document.getElementById('brainImage').value.trim();
-    const differentiation = document.getElementById('differentiation').value.trim();
-    const changes = document.getElementById('changes').value.trim();
-    const liquorSpaces = document.getElementById('liquorSpaces').value.trim();
-    const conclusion = document.getElementById('conclusion').value.trim();
-    const advice = document.getElementById('advice').value.trim();
-    const doctor = document.getElementById('doctor').value.trim();
+function renderSummary() {
+    const genderInput = document.querySelector('input[name="gender"]:checked');
+    const methods = Array.from(document.querySelectorAll('input[name="method"]:checked')).map(({ value }) => value).join(', ');
 
-    if (!date || !fname || !department || !gender || !birthYear || !brainImage || !differentiation || !changes || !liquorSpaces || !conclusion || !advice || !doctor) {
-        alert('Ähli meýdançalar doldurumaly.');
+    const fields = {
+        date: document.getElementById('research-date')?.value,
+        patientName: document.getElementById('patient-name')?.value.trim(),
+        department: document.getElementById('department')?.value.trim(),
+        gender: genderInput?.value,
+        birthYear: document.getElementById('birth-year')?.value,
+        patientCode: document.getElementById('patient-code')?.value.trim(),
+        methods,
+        researchFrequency: document.getElementById('research-frequency')?.value,
+        artifactNotes: document.getElementById('artifact-notes')?.value,
+        skullShape: document.getElementById('skull-shape')?.value,
+        cranialSutures: document.getElementById('cranial-sutures')?.value,
+        skullSymmetry: document.getElementById('skull-symmetry')?.value,
+        cranialFossa: document.getElementById('cranial-fossa')?.value,
+        postoperativeChanges: document.getElementById('postoperative-changes')?.value,
+        differentiation: document.getElementById('differentiation')?.value,
+        heterotopia: document.getElementById('heterotopia')?.value,
+        hippocampusSymmetry: document.getElementById('hippocampus-symmetry')?.value,
+        hippocampusLesions: document.getElementById('hippocampus-lesions')?.value,
+        parenchymaChanges: document.getElementById('parenchyma-changes')?.value.trim(),
+        liquorSpaces: document.getElementById('liquor-spaces')?.value.trim(),
+        conclusion: document.getElementById('conclusion')?.value.trim(),
+        advice: document.getElementById('advice')?.value.trim(),
+        doctor: document.getElementById('doctor')?.value.trim(),
+    };
+
+    const requiredFields = ['date', 'patientName', 'department', 'gender', 'birthYear', 'conclusion', 'advice', 'doctor'];
+    const missing = requiredFields.filter(key => !fields[key]);
+
+    if (missing.length) {
+        alert('Ähli zerur meýdançalar dolduryň.');
         return;
     }
 
     const result = `
-        <strong>Senesi:</strong> ${date} <br>
-        <strong>Familiyasy, ady:</strong> ${fname} <br>
-        <strong>Bölüm:</strong> ${department} <br>
-        <strong>Jynsy:</strong> ${gender} <br>
-        <strong>Doglan ýyly:</strong> ${birthYear} <br>
-        <strong>Näsagyň kody:</strong> ${code} <br>
-        <strong>Barlag usuly:</strong> ${methods} <br>
-        <strong>Artefaktlar:</strong> ${artifacts} <br>
-        <strong>Barlag:</strong> ${exam} <br>
-        <strong>Kelleçanagyň şekili:</strong> ${brainImage} <br>
-        <strong>Ak we çal maddanyň differensasiýasy:</strong> ${differentiation} <br>
-        <strong>Beýni parenhimasynyň ojaklaýyn üýtgemeleri:</strong> ${changes} <br>
-        <strong>Likwor saklaýan giňişlikler:</strong> ${liquorSpaces} <br>
-        <strong>Netije:</strong> ${conclusion} <br>
-        <strong>Maslahat:</strong> ${advice} <br>
-        <strong>Lukman:</strong> ${doctor}
+        <h3>Umumy maglumatlar</h3>
+        <ul>
+          <li><strong>Senesi:</strong> ${fields.date}</li>
+          <li><strong>Familiyasy, ady:</strong> ${fields.patientName}</li>
+          <li><strong>Bölüm:</strong> ${fields.department}</li>
+          <li><strong>Jynsy:</strong> ${fields.gender}</li>
+          <li><strong>Doglan ýyly:</strong> ${fields.birthYear}</li>
+          <li><strong>Näsagyň kody:</strong> ${fields.patientCode || '—'}</li>
+          <li><strong>Barlag usuly:</strong> ${fields.methods || 'Saýlanmady'}</li>
+          <li><strong>Barlagyň görnüşi:</strong> ${fields.researchFrequency}</li>
+          <li><strong>Artefaktlar:</strong> ${fields.artifactNotes}</li>
+        </ul>
+        <h3>Protokol</h3>
+        <ul>
+          <li><strong>Kelle çanak:</strong> ${fields.skullShape}</li>
+          <li><strong>Tikinleri:</strong> ${fields.cranialSutures}</li>
+          <li><strong>Simmetriýa:</strong> ${fields.skullSymmetry}</li>
+          <li><strong>Kelleçanagyň çukurjuklary:</strong> ${fields.cranialFossa}</li>
+          <li><strong>Operasiýadan soňky üýtgemeler:</strong> ${fields.postoperativeChanges}</li>
+          <li><strong>Ak we çal maddanyň differensasiýasy:</strong> ${fields.differentiation}</li>
+          <li><strong>Geterotopiýa:</strong> ${fields.heterotopia}</li>
+          <li><strong>Gippokamp simmetriýasy:</strong> ${fields.hippocampusSymmetry}</li>
+          <li><strong>Gippokampdaky ojaklar:</strong> ${fields.hippocampusLesions}</li>
+          ${fields.parenchymaChanges ? `<li><strong>Beýni parenhimasynyň ojaklaýyn üýtgemeleri:</strong> ${fields.parenchymaChanges}</li>` : ''}
+          ${fields.liquorSpaces ? `<li><strong>Likwor saklaýan giňişlikler:</strong> ${fields.liquorSpaces}</li>` : ''}
+        </ul>
+        <h3>Netije we maslahat</h3>
+        <ul>
+          <li><strong>Netije:</strong> ${fields.conclusion}</li>
+          <li><strong>Maslahat:</strong> ${fields.advice}</li>
+          <li><strong>Lukman:</strong> ${fields.doctor}</li>
+        </ul>
     `;
-    document.getElementById('result').innerHTML = result;
+
+    const resultContainer = document.getElementById('result');
+    if (resultContainer) {
+        resultContainer.innerHTML = result;
+    }
 }

--- a/styles.css
+++ b/styles.css
@@ -56,16 +56,11 @@ h2 {
 }
 
 #research-form {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
     font-size: 14px;
     margin: 10px 0 20px;
-}
-
-#research-form input[type="date"] {
-    width: auto;
-    padding: 6px 8px;
 }
 
 label {
@@ -74,11 +69,40 @@ label {
     color: #333;
 }
 
-input[type="text"], 
-input[type="date"], 
-input[type="number"], 
-input[type="radio"], 
-input[type="checkbox"] {
+.form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 16px;
+}
+
+.field-group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.field-label {
+    font-weight: bold;
+    color: #333;
+}
+
+.option-row {
+    display: flex;
+    gap: 12px;
+}
+
+.option-column {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+input[type="text"],
+input[type="date"],
+input[type="number"],
+input[type="radio"],
+input[type="checkbox"],
+textarea {
     width: 100%;
     padding: 10px;
     margin-bottom: 15px;
@@ -103,6 +127,16 @@ button {
     cursor: pointer;
     font-size: 16px;
     transition: background-color 0.3s;
+}
+
+.form-actions {
+    display: flex;
+    gap: 12px;
+}
+
+.form-actions button {
+    width: auto;
+    flex: 1;
 }
 
 button:hover {


### PR DESCRIPTION
## Summary
- build a complete MRI research form with unique field ids and add export controls
- update the client-side logic to read the real fields, render a summary, and feed Word export
- refresh styling for the new grid-based form layout and inputs

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692406edeec483299373f60dc6f251ee)