### PR TITLE
Add RSNA brain MRI template autofill

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,19 +32,20 @@
       <aside class="sidebar" aria-label="Kömekçi maglumatlar">
         <div class="reference-card" aria-label="Nusga maglumatlary">
           <div class="reference-header">
-            <span class="pill">Beýni_kada_.docx</span>
-            <p class="reference-title">Nusga hasabatdan alnan mazmunlar</p>
-            <p class="reference-subtitle">Meýdançalary doldurmak üçin görkezme hökmünde ulanyň.</p>
+            <span class="pill">RSNA şablony</span>
+            <p class="reference-title">KELLE BEÝNINIŇ MR TOMOGRAFIÝASY</p>
+            <p class="reference-subtitle">Şu mazmun awtodolduryş üçin esas bolup hyzmat edýär.</p>
           </div>
           <ul class="reference-list">
-            <li><strong>Barlagyň senesi:</strong> 24.11.2025 ý.</li>
-            <li><strong>Barlag usuly:</strong> Umumy, T1, T2, T2_tirm, diffuz we MRT angiografiýa usulda tra, sag, cor kesimlerde.</li>
-            <li><strong>Artefaktlar:</strong> Ýok. | <strong>Barlag:</strong> Ilkinji gezek.</li>
-            <li><strong>Kelleçanagyň şekili:</strong> Mezosefal tipli, simmetrik.</li>
-            <li><strong>Differensasiýa:</strong> Ak we çal maddanyň aýdyň, ojaklaýyn üýtgemeler ýok.</li>
-            <li><strong>Likwor giňişlikleri:</strong> Garynjyklary giňelmedik; bazal sisternalar we subarahnoidal keşler kadaly.</li>
-            <li><strong>Süňkler we beýleki gurluşlar:</strong> Kelleçanagyň eňňidinde patologiýa ýok, gözhanalar dogry ösen.</li>
-            <li><strong>Netije:</strong> Kelle beýnide organiki üýtgeşme anyklanmady. | <strong>Maslahat:</strong> Newropatolog maslahaty.</li>
+            <li><strong>Senesi:</strong> 09.12.2025 ý.</li>
+            <li><strong>Näsag:</strong> Amanow Aman | <strong>Bölüm:</strong> Ambulator | <strong>Jynsy:</strong> Erkek | <strong>Doglan ýyly:</strong> 01.01.2001 ý.</li>
+            <li><strong>Barlag usuly:</strong> Umumy, T1, T2, T2_tirm, diffuz we MRT angiografiýa; tra, sag, cor kesimlerde.</li>
+            <li><strong>Artefaktlar / barlag:</strong> Artefaktlar ýok, ilkinji gezek.</li>
+            <li><strong>Simmetriýa:</strong> Mezosefal, simmetrik; tikinleri kadaly.</li>
+            <li><strong>Parenhima:</strong> Ojak ýüze çykarylmaýar, geterotopiýa ýok, gippokamp simmetrik.</li>
+            <li><strong>Likwor giňişlikleri:</strong> Garynjyklary giňelmedik, bazal sisternalar we konweksital subarahnoidal keşler kadaly.</li>
+            <li><strong>Beýleki:</strong> Türk eýeri we gipofiz kadaly, orbitalar we beýnijik aýratynlyksyz, süňk gurluşlary patologiýasyz.</li>
+            <li><strong>Netije:</strong> Organiki üýtgeşme anyklanmady. | <strong>Maslahat:</strong> Newropatolog lukmanlaryň maslahaty.</li>
           </ul>
         </div>
 
@@ -122,8 +123,12 @@
                   <div class="field-group">
                     <span class="field-label">Barlag usuly</span>
                     <div class="option-column">
+                      <label><input type="checkbox" id="method-basic" name="method" value="Umumy" /> Umumy</label>
                       <label><input type="checkbox" id="method-t1" name="method" value="T1" /> T1</label>
                       <label><input type="checkbox" id="method-t2" name="method" value="T2" /> T2</label>
+                      <label><input type="checkbox" id="method-t2tirm" name="method" value="T2_tirm" /> T2_tirm</label>
+                      <label><input type="checkbox" id="method-diff" name="method" value="Diffuz" /> Diffuz</label>
+                      <label><input type="checkbox" id="method-angiography" name="method" value="MRT angiografiýa" /> MRT angiografiýa</label>
                       <label><input type="checkbox" id="method-fla" name="method" value="FLAIR" /> FLAIR</label>
                     </div>
                   </div>
@@ -145,6 +150,12 @@
                       <option value="Näsagyň hereket artefaktlary.">Näsagyň hereket artefaktlary.</option>
                       <option value="Metal artefaktlar.">Metal artefaktlar.</option>
                     </select>
+                  </div>
+                  <div class="field-group">
+                    <label for="slice-planes">
+                      Kesim ugry
+                      <span class="tooltip" aria-label="Tra, sag, cor ýaly ugrukmalar">?</span></label>
+                    <input type="text" id="slice-planes" name="slice-planes" placeholder="mysal: tra, sag, cor kesimlerde" />
                   </div>
                 </div>
               </div>
@@ -257,6 +268,7 @@
                 </div>
                 <div class="form-actions">
                   <button type="submit">Hasabat döret</button>
+                  <button type="button" id="fillTemplate" class="ghost">RSNA şablonyny doldur</button>
                   <button type="button" id="saveWord">Word görnüşde ýükle</button>
                 </div>
               </div>

--- a/saveWord.js
+++ b/saveWord.js
@@ -17,6 +17,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 methods,
                 researchFrequency: document.getElementById('research-frequency')?.value || '',
                 artifactNotes: document.getElementById('artifact-notes')?.value || '',
+                slicePlanes: document.getElementById('slice-planes')?.value || '',
                 skullShape: document.getElementById('skull-shape')?.value || '',
                 cranialSutures: document.getElementById('cranial-sutures')?.value || '',
                 skullSymmetry: document.getElementById('skull-symmetry')?.value || '',
@@ -56,6 +57,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     <div class="section"><span class="label">Barlag usuly:</span> ${methods || '—'}</div>
                     <div class="section"><span class="label">Barlagyň gaýtalanmasy:</span> ${formData.researchFrequency}</div>
                     <div class="section"><span class="label">Artefaktlar:</span> ${formData.artifactNotes}</div>
+                    <div class="section"><span class="label">Kesim ugry:</span> ${formData.slicePlanes}</div>
                     <div class="section"><span class="label">Kelle çanagy:</span> ${formData.skullShape}</div>
                     <div class="section"><span class="label">Tikinleri:</span> ${formData.cranialSutures}</div>
                     <div class="section"><span class="label">Simmetriýa:</span> ${formData.skullSymmetry}</div>

--- a/script.js
+++ b/script.js
@@ -3,6 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const dateInput = document.getElementById('research-date');
     const tabs = document.querySelectorAll('.tab');
     const copyButton = document.getElementById('copyReport');
+    const templateButton = document.getElementById('fillTemplate');
 
     ensureMessageContainer();
 
@@ -24,6 +25,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (copyButton) {
         copyButton.addEventListener('click', copyReport);
+    }
+
+    if (templateButton) {
+        templateButton.addEventListener('click', () => {
+            populateTemplate();
+            renderSummary();
+        });
     }
 });
 
@@ -177,6 +185,7 @@ function renderSummary() {
         heterotopia: getField('heterotopia', 'Geterotopiýa'),
         hippocampusSymmetry: getField('hippocampus-symmetry', 'Gippokamp simmetriýasy'),
         hippocampusLesions: getField('hippocampus-lesions', 'Gippokampdaky ojaklar'),
+        slicePlanes: getField('slice-planes', 'Kesim ugry'),
         parenchymaChanges: getField('parenchyma-changes', 'Beýni parenhimasynyň ojaklaýyn üýtgemeleri'),
         liquorSpaces: getField('liquor-spaces', 'Likwor saklaýan giňişlikler'),
         conclusion: getField('conclusion', 'Netije'),
@@ -210,6 +219,7 @@ function renderSummary() {
         heterotopia: fieldsWithElements.heterotopia.value,
         hippocampusSymmetry: fieldsWithElements.hippocampusSymmetry.value,
         hippocampusLesions: fieldsWithElements.hippocampusLesions.value,
+        slicePlanes: fieldsWithElements.slicePlanes.value.trim(),
         parenchymaChanges: fieldsWithElements.parenchymaChanges.value.trim(),
         liquorSpaces: fieldsWithElements.liquorSpaces.value.trim(),
         conclusion: fieldsWithElements.conclusion.value.trim(),
@@ -284,6 +294,7 @@ function renderSummary() {
           <li><strong>Barlag usuly:</strong> ${fields.methods || 'Saýlanmady'}</li>
           <li><strong>Barlagyň görnüşi:</strong> ${fields.researchFrequency}</li>
           <li><strong>Artefaktlar:</strong> ${fields.artifactNotes}</li>
+          ${fields.slicePlanes ? `<li><strong>Kesim ugry:</strong> ${fields.slicePlanes}</li>` : ''}
         </ul>
         <h3>Protokol</h3>
         <ul>
@@ -305,6 +316,20 @@ function renderSummary() {
           <li><strong>Maslahat:</strong> ${fields.advice}</li>
           <li><strong>Lukman:</strong> ${fields.doctor}</li>
         </ul>
+        <div class="template-block" aria-label="Şablon görnüşi">
+          <p class="template-title">KELLE BEÝNINIŇ MR TOMOGRAFIÝASY</p>
+          <p><strong>${fields.date}</strong> | <strong>${fields.patientName}</strong> | ${fields.department}</p>
+          <p>Jynsy: ${fields.gender}. Doglan ýyly: ${fields.birthYear}. Näsagyň kody: ${fields.patientCode || '__ ____'}.</p>
+          <p>Barlag usuly: ${fields.methods || 'Saýlanmady'} ${fields.slicePlanes ? `(${fields.slicePlanes})` : ''}. Artefaktlar: ${fields.artifactNotes} Barlag: ${fields.researchFrequency}</p>
+          <p>Kelleçanagyň şekili: ${fields.skullShape} ${fields.skullSymmetry}</p>
+          <p>Ak we çal maddanyň differensasiýasy: ${fields.differentiation} ${fields.heterotopia ? `Geterotopiýa: ${fields.heterotopia}` : ''}</p>
+          <p>Gippokamp: ${fields.hippocampusSymmetry} | ${fields.hippocampusLesions}</p>
+          ${fields.liquorSpaces ? `<p>Likwor saklaýan giňişlikler: ${fields.liquorSpaces}</p>` : ''}
+          ${fields.parenchymaChanges ? `<p>Beýni parenhimasynyň üýtgemeleri: ${fields.parenchymaChanges}</p>` : ''}
+          <p><strong>Netije:</strong> ${fields.conclusion}</p>
+          <p><strong>Maslahat:</strong> ${fields.advice}</p>
+          <p><strong>Lukman:</strong> ${fields.doctor}</p>
+        </div>
     `;
 
     resultContainer.innerHTML = result;
@@ -312,6 +337,77 @@ function renderSummary() {
     if (copyButton) {
         copyButton.disabled = false;
     }
+}
+
+function populateTemplate() {
+    clearMessages();
+
+    const template = {
+        date: '2025-12-09',
+        patientName: 'Amanow Aman',
+        department: 'Ambulator',
+        gender: 'Erkek',
+        birthYear: '2001',
+        patientCode: '__ ____',
+        methods: ['Umumy', 'T1', 'T2', 'T2_tirm', 'Diffuz', 'MRT angiografiýa'],
+        researchFrequency: 'Ilkinji gezek.',
+        artifactNotes: 'Artefaktlar ýok.',
+        slicePlanes: 'tra, sag, cor kesimlerde.',
+        skullShape: 'Mezosefal tipli.',
+        cranialSutures: 'kadaly ýagdaýda.',
+        skullSymmetry: 'Simmetrik.',
+        cranialFossa: 'Kadaly.',
+        postoperativeChanges: 'ýok.',
+        differentiation: 'aýdyň. Ojaklaýyn üýtgemeleri bellenmeýär.',
+        heterotopia: 'bellenmeýar.',
+        hippocampusSymmetry: 'Simmetrik.',
+        hippocampusLesions: 'ojaklaýyn üýtgeşme ýok.',
+        parenchymaChanges: 'Beýni parenhimasynyň ojaklaýyn üýtgemeleri anyklanmaýar. Geterotopik ojaklar ýüze çykarylmaýar. Gippokampyň töweregi simmetrik ojaklaýyn üýtgemeleri bellenmeýär.',
+        liquorSpaces: 'Beýni garynjyklary: giňelmedik (öz ýaşyna gabat gelýär); simmetrik. Garynjyk ara germewi: adaty. Bazal sisternalar we konweksital subarahnoidal keşler: giňelmedik, simmetrik, kadaly ýerleşen.',
+        conclusion: 'Kelle beýnide organiki üýtgeşme anyklanmady.',
+        advice: 'Newropatolog lukmanlaryň maslahaty.',
+        doctor: 'Döwletow M.M.',
+    };
+
+    const setValue = (id, value) => {
+        const element = document.getElementById(id);
+        if (element) element.value = value;
+    };
+
+    setValue('research-date', template.date);
+    setValue('patient-name', template.patientName);
+    setValue('department', template.department);
+    setValue('birth-year', template.birthYear);
+    setValue('patient-code', template.patientCode);
+    setValue('research-frequency', template.researchFrequency);
+    setValue('artifact-notes', template.artifactNotes);
+    setValue('slice-planes', template.slicePlanes);
+    setValue('skull-shape', template.skullShape);
+    setValue('cranial-sutures', template.cranialSutures);
+    setValue('skull-symmetry', template.skullSymmetry);
+    setValue('cranial-fossa', template.cranialFossa);
+    setValue('postoperative-changes', template.postoperativeChanges);
+    setValue('differentiation', template.differentiation);
+    setValue('heterotopia', template.heterotopia);
+    setValue('hippocampus-symmetry', template.hippocampusSymmetry);
+    setValue('hippocampus-lesions', template.hippocampusLesions);
+    setValue('parenchyma-changes', template.parenchymaChanges);
+    setValue('liquor-spaces', template.liquorSpaces);
+    setValue('conclusion', template.conclusion);
+    setValue('advice', template.advice);
+    setValue('doctor', template.doctor);
+
+    const genderInput = document.querySelector(`input[name="gender"][value="${template.gender}"]`);
+    if (genderInput) {
+        genderInput.checked = true;
+    }
+
+    const methodInputs = document.querySelectorAll('input[name="method"]');
+    methodInputs.forEach(input => {
+        input.checked = template.methods.includes(input.value);
+    });
+
+    showSuccess('RSNA görnüşindäki nusga maglumatlary meýdançalara ýerleşdirildi.');
 }
 
 async function copyReport() {

--- a/styles.css
+++ b/styles.css
@@ -367,6 +367,18 @@ button:disabled {
     box-shadow: none;
 }
 
+.ghost {
+    background: #fff;
+    color: var(--rsna-navy);
+    border: 1px solid var(--rsna-border);
+    box-shadow: none;
+}
+
+.ghost:hover {
+    background: #eef3ff;
+    border-color: var(--rsna-blue);
+}
+
 .form-actions {
     display: flex;
     gap: 12px;
@@ -498,6 +510,22 @@ details summary {
     cursor: pointer;
     font-weight: 700;
     color: var(--text-primary);
+}
+
+.template-block {
+    margin-top: 12px;
+    padding: 14px 16px;
+    border-radius: 10px;
+    border: 1px solid var(--rsna-border);
+    background: #f8fbff;
+    line-height: 1.5;
+}
+
+.template-title {
+    margin: 0 0 4px;
+    font-weight: 800;
+    color: var(--rsna-navy);
+    letter-spacing: 0.05em;
 }
 
 @media (max-width: 980px) {


### PR DESCRIPTION
## Summary
- add RSNA-based reference panel and ghost action for auto-filling the form with provided template data
- expand examination inputs with additional modalities, slice plane entry, and template-style narrative block in results
- include new fields in Word export and update styling for template/ghost buttons

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a9d85edf4832986c3f554ebae55af)