### PR TITLE
Add auto-intake profiles and refreshed MRI report layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,53 +13,67 @@
     <header class="rsna-hero" role="banner">
       <div class="rsna-brand">
         <div class="rsna-mark" aria-hidden="true">RSNA</div>
-        <div>
-          <p class="eyebrow">The Radiological Society of North America</p>
-          <h1>Beýni MRT protokoly</h1>
+        <div class="brand-text">
+          <p class="eyebrow">MRI report studio</p>
+          <h1>RSNA taýdan şekillendirilen beýni MRT hasabaty</h1>
           <p class="lead">
-            RSNA-nyň kliniki stili boýunça tertipleşdirilen beýan we meýdançalar.
+            Lukman-radiologlar üçin akylly, awtoblokirlenýän protokol: kliniki maglumatlary ýygnamak, şeýle hem hasabaty sekuntda çykarmak üçin ähli meýdançalar taýýarlanyldy.
           </p>
+          <div class="meta-grid" aria-label="Ulgam ýagdaýy">
+            <div class="meta-chip">
+              <span class="meta-label">Protokol wersiýasy</span>
+              <strong>RSNA Neuro v2.1</strong>
+            </div>
+            <div class="meta-chip">
+              <span class="meta-label">Şablonlaryň sany</span>
+              <strong>3 kliniki profil</strong>
+            </div>
+            <div class="meta-chip">
+              <span class="meta-label">Awtodolduryş</span>
+              <strong>Peýdalanyşa taýýar</strong>
+            </div>
+          </div>
         </div>
       </div>
-      <div class="rsna-meta">
+      <div class="rsna-meta" aria-label="Rasmýeti maglumat">
         <p>Türkmenistanyň Saglygy goraýyş we derman senagaty ministrligi</p>
-        <p>TSG we DS ministrliginiň № 7/18-23 haty esasynda 022 görnüşli lukmançylyk resminamasy HSMM-i tarapyndan 23.04.2004-nji ýylyň №82 buýruk esasynda tassyklanan</p>
+        <p>022 görnüşli lukmançylyk resminamasy HSMM-i tarapyndan 23.04.2004-nji ýylyň №82 buýrugy esasynda tassyklanan.</p>
         <p><strong>Edaranyň ady:</strong> KYKMH</p>
       </div>
     </header>
 
     <main class="workspace" aria-label="RSNA laýyk MRT meýdançalary">
-      <aside class="sidebar" aria-label="Kömekçi maglumatlar">
-        <div class="reference-card" aria-label="Nusga maglumatlary">
-          <div class="reference-header">
-            <span class="pill">RSNA şablony</span>
-            <p class="reference-title">KELLE BEÝNINIŇ MR TOMOGRAFIÝASY</p>
-            <p class="reference-subtitle">Şu mazmun awtodolduryş üçin esas bolup hyzmat edýär.</p>
+        <aside class="sidebar" aria-label="Kömekçi maglumatlar">
+          <div class="reference-card" aria-label="Nusga maglumatlary">
+            <div class="reference-header">
+              <span class="pill">Lukman üçin göz öňünde tutuldy</span>
+              <p class="reference-title">RSNA neuro şablonynyň goldawy</p>
+              <p class="reference-subtitle">Bir basyşda kadaly ýa-da kliniki ýagdaýlara laýyk doly dolduryş.</p>
+            </div>
+            <ul class="reference-list">
+              <li><strong>Senesi:</strong> 09.12.2025 ý.</li>
+              <li><strong>Näsag:</strong> Amanow Aman | <strong>Bölüm:</strong> Ambulator | <strong>Jynsy:</strong> Erkek | <strong>Doglan ýyly:</strong> 01.01.2001 ý.</li>
+              <li><strong>Barlag usuly:</strong> Umumy, T1, T2, T2_tirm, Diffuz, MRT angiografiýa.</li>
+              <li><strong>Artefaktlar / barlag:</strong> Artefaktlar ýok, ilkinji gezek.</li>
+              <li><strong>Simmetriýa:</strong> Mezosefal, simmetrik; tikinleri kadaly.</li>
+              <li><strong>Parenhima:</strong> Ojak ýüze çykarylmaýar, geterotopiýa ýok, gippokamp simmetrik.</li>
+              <li><strong>Likwor giňişlikleri:</strong> Garynjyklary giňelmedik, bazal sisternalar we konweksital subarahnoidal keşler kadaly.</li>
+              <li><strong>Beýleki:</strong> Türk eýeri we gipofiz kadaly, orbitalar we beýnijik aýratynlyksyz.</li>
+              <li><strong>Netije:</strong> Organiki üýtgeşme anyklanmady. | <strong>Maslahat:</strong> Newropatolog maslahatyny teklip ediň.</li>
+            </ul>
           </div>
-          <ul class="reference-list">
-            <li><strong>Senesi:</strong> 09.12.2025 ý.</li>
-            <li><strong>Näsag:</strong> Amanow Aman | <strong>Bölüm:</strong> Ambulator | <strong>Jynsy:</strong> Erkek | <strong>Doglan ýyly:</strong> 01.01.2001 ý.</li>
-            <li><strong>Barlag usuly:</strong> Umumy, T1, T2, T2_tirm, diffuz we MRT angiografiýa; tra, sag, cor kesimlerde.</li>
-            <li><strong>Artefaktlar / barlag:</strong> Artefaktlar ýok, ilkinji gezek.</li>
-            <li><strong>Simmetriýa:</strong> Mezosefal, simmetrik; tikinleri kadaly.</li>
-            <li><strong>Parenhima:</strong> Ojak ýüze çykarylmaýar, geterotopiýa ýok, gippokamp simmetrik.</li>
-            <li><strong>Likwor giňişlikleri:</strong> Garynjyklary giňelmedik, bazal sisternalar we konweksital subarahnoidal keşler kadaly.</li>
-            <li><strong>Beýleki:</strong> Türk eýeri we gipofiz kadaly, orbitalar we beýnijik aýratynlyksyz, süňk gurluşlary patologiýasyz.</li>
-            <li><strong>Netije:</strong> Organiki üýtgeşme anyklanmady. | <strong>Maslahat:</strong> Newropatolog lukmanlaryň maslahaty.</li>
-          </ul>
-        </div>
 
-        <div class="workflow-card" aria-label="Iş akymy">
-          <p class="eyebrow">Bazar logikasy</p>
-          <h3>Hasabaty taýýarlamagyň tapgyrlary</h3>
-          <ol class="guide-list">
-            <li>Ilki bilen näsag we barlag baradaky maglumatlary giriziň.</li>
-            <li>Ulgam we metodiki aýratynlyklary belläp, möhüm struktur seljermeleri giriziň.</li>
-            <li>Netije bilen maslahaty aýdyňlaşdyryp, jogapkär lukmanyň adyny görkezmegiňizi unutmaň.</li>
-            <li>Bar maglumatlary ýazga alyň: hasabaty dörediň, nusgasyny göçüriň ýa-da Word görnüşde ýükleň.</li>
-          </ol>
-        </div>
-      </aside>
+          <div class="workflow-card" aria-label="Iş akymy">
+            <p class="eyebrow">Kliniki iş akymy</p>
+            <h3>Hasabaty taýýarlamagyň tapgyrlary</h3>
+            <ol class="guide-list">
+              <li>Auto Intake arkaly profil saýlaň ýa-da zerur meýdançalary el bilen dolduryň.</li>
+              <li>Ulgam we strukturalar boýunça bellikleri giriziň, möhüm ojaklary ýüze çykaranyňyzda bellik goýuň.</li>
+              <li>Netije we maslahat bölüminde kliniki kararyňyzy ýazyp, jogapkär lukmanyň adyny goşuň.</li>
+              <li>Hasabaty döredip, göçüriň ýa-da Word görnüşine eksport ediň.</li>
+            </ol>
+          </div>
+        </aside>
 
       <section class="content" aria-label="Barlag protokoly">
         <section class="protocol">
@@ -67,9 +81,47 @@
             <div>
               <p class="eyebrow">Kelle beýniniň MRT</p>
               <h2>RSNA laýyk maglumat görkezişi</h2>
-              <p class="section-lead">Iş akymy boýunça toparlara bölünýän meýdançalar.</p>
+              <p class="section-lead">Akylly awtodolduryş, kliniki profiller we eksport opsiýalary bilen güýçlendirildi.</p>
             </div>
             <div id="messages" class="messages" role="alert" aria-live="polite"></div>
+          </div>
+
+          <div class="auto-intake" aria-label="Awtodolduryş merkezi">
+            <div class="auto-meta">
+              <p class="eyebrow">Auto Intake</p>
+              <h3>Profil saýlap, meýdançalary awtomatiki dolduryň</h3>
+              <p>
+                Lukman-radiologlaryň işini çaltlaşdyrmak üçin üç sany taýýar kliniki profil bar: kadaly, diskirkulýator ojakly we
+                operasiýadan soňky gözegçilik. Profil saýlananda ähli degişli meýdançalar hem-de metodiki bellikler doldurylýar.
+              </p>
+              <div class="intake-controls">
+                <div class="control-stack">
+                  <label for="profile-picker">Kliniki profil</label>
+                  <select id="profile-picker" name="profile-picker">
+                    <option value="normal">Kadaly MRT (profilaktika)</option>
+                    <option value="vascular">Diskirkulýator üýtgemeleri şübhelenýär</option>
+                    <option value="postop">Operasiýadan soňky kontrol</option>
+                  </select>
+                </div>
+                <div class="control-stack">
+                  <label for="profile-note">Profil barada bellik</label>
+                  <p class="muted" id="profile-note">Kadaly profil: anyk ojak ýok, artefaktlar ýok, standart kesimlerde doly protokol.</p>
+                </div>
+                <div class="intake-actions">
+                  <button type="button" id="applyProfile">Profil boýunça doldur</button>
+                  <button type="button" id="fillTemplate" class="ghost">RSNA şablonyny doldur</button>
+                </div>
+              </div>
+            </div>
+            <div class="auto-help">
+              <p class="eyebrow">Awtomatlaşdyrma mümkinçilikleri</p>
+              <ul>
+                <li>Senäni häzirki güne awtomatiki goýýar.</li>
+                <li>Barlag usullaryny profil boýunça saýlaýar, kesim ugry hem goşulýar.</li>
+                <li>Likwor giňişlikleri, parenhima we gippokamp boýunça tekst bellikleri doly doldurylýar.</li>
+                <li>Netije we maslahat bölümleri profil bilen sazlaşykly ýazylýar.</li>
+              </ul>
+            </div>
           </div>
 
           <div class="workflow-grid">

--- a/script.js
+++ b/script.js
@@ -4,6 +4,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const tabs = document.querySelectorAll('.tab');
     const copyButton = document.getElementById('copyReport');
     const templateButton = document.getElementById('fillTemplate');
+    const profilePicker = document.getElementById('profile-picker');
+    const applyProfileButton = document.getElementById('applyProfile');
+    const profileNote = document.getElementById('profile-note');
 
     ensureMessageContainer();
 
@@ -33,7 +36,27 @@ document.addEventListener('DOMContentLoaded', () => {
             renderSummary();
         });
     }
+
+    if (applyProfileButton && profilePicker) {
+        applyProfileButton.addEventListener('click', () => {
+            populateProfile(profilePicker.value);
+            renderSummary();
+        });
+
+        profilePicker.addEventListener('change', () => {
+            const note = PROFILE_NOTES[profilePicker.value];
+            if (profileNote && note) {
+                profileNote.textContent = note;
+            }
+        });
+    }
 });
+
+const PROFILE_NOTES = {
+    normal: 'Kadaly profil: anyk ojak ýok, artefaktlar ýok, standart kesimlerde doly protokol.',
+    vascular: 'Diskirkulýator üýtgeşmeler: Fazekas 1–2 derejesine laýyk bellikler we diffuz ojaklar boýunça ýazgy.',
+    postop: 'Operasiýadan soň: kraniotomiýa yzlary, kontrollik angiografiýa bellikleri we gollanma maslahaty bilen.',
+};
 
 function initTabs(tabs) {
     const panels = document.querySelectorAll('.tab-panel');
@@ -369,33 +392,28 @@ function populateTemplate() {
         doctor: 'Döwletow M.M.',
     };
 
-    const setValue = (id, value) => {
-        const element = document.getElementById(id);
-        if (element) element.value = value;
-    };
-
-    setValue('research-date', template.date);
-    setValue('patient-name', template.patientName);
-    setValue('department', template.department);
-    setValue('birth-year', template.birthYear);
-    setValue('patient-code', template.patientCode);
-    setValue('research-frequency', template.researchFrequency);
-    setValue('artifact-notes', template.artifactNotes);
-    setValue('slice-planes', template.slicePlanes);
-    setValue('skull-shape', template.skullShape);
-    setValue('cranial-sutures', template.cranialSutures);
-    setValue('skull-symmetry', template.skullSymmetry);
-    setValue('cranial-fossa', template.cranialFossa);
-    setValue('postoperative-changes', template.postoperativeChanges);
-    setValue('differentiation', template.differentiation);
-    setValue('heterotopia', template.heterotopia);
-    setValue('hippocampus-symmetry', template.hippocampusSymmetry);
-    setValue('hippocampus-lesions', template.hippocampusLesions);
-    setValue('parenchyma-changes', template.parenchymaChanges);
-    setValue('liquor-spaces', template.liquorSpaces);
-    setValue('conclusion', template.conclusion);
-    setValue('advice', template.advice);
-    setValue('doctor', template.doctor);
+    setFieldValue('date', template.date);
+    setFieldValue('patientName', template.patientName);
+    setFieldValue('department', template.department);
+    setFieldValue('birthYear', template.birthYear);
+    setFieldValue('patientCode', template.patientCode);
+    setFieldValue('researchFrequency', template.researchFrequency);
+    setFieldValue('artifactNotes', template.artifactNotes);
+    setFieldValue('slicePlanes', template.slicePlanes);
+    setFieldValue('skullShape', template.skullShape);
+    setFieldValue('cranialSutures', template.cranialSutures);
+    setFieldValue('skullSymmetry', template.skullSymmetry);
+    setFieldValue('cranialFossa', template.cranialFossa);
+    setFieldValue('postoperativeChanges', template.postoperativeChanges);
+    setFieldValue('differentiation', template.differentiation);
+    setFieldValue('heterotopia', template.heterotopia);
+    setFieldValue('hippocampusSymmetry', template.hippocampusSymmetry);
+    setFieldValue('hippocampusLesions', template.hippocampusLesions);
+    setFieldValue('parenchymaChanges', template.parenchymaChanges);
+    setFieldValue('liquorSpaces', template.liquorSpaces);
+    setFieldValue('conclusion', template.conclusion);
+    setFieldValue('advice', template.advice);
+    setFieldValue('doctor', template.doctor);
 
     const genderInput = document.querySelector(`input[name="gender"][value="${template.gender}"]`);
     if (genderInput) {
@@ -408,6 +426,175 @@ function populateTemplate() {
     });
 
     showSuccess('RSNA görnüşindäki nusga maglumatlary meýdançalara ýerleşdirildi.');
+}
+
+function populateProfile(profile) {
+    clearMessages();
+
+    const profiles = {
+        normal: {
+            date: new Date().toISOString().split('T')[0],
+            patientName: 'Amanow Aman',
+            department: 'Ambulator',
+            gender: 'Erkek',
+            birthYear: '1995',
+            patientCode: 'N-2024-001',
+            methods: ['Umumy', 'T1', 'T2', 'T2_tirm', 'Diffuz', 'MRT angiografiýa'],
+            researchFrequency: 'Ilkinji gezek.',
+            artifactNotes: 'Artefaktlar ýok.',
+            slicePlanes: 'tra, sag, cor kesimlerde.',
+            skullShape: 'Mezosefal tipli.',
+            cranialSutures: 'kadaly ýagdaýda.',
+            skullSymmetry: 'Simmetrik.',
+            cranialFossa: 'Kadaly.',
+            postoperativeChanges: 'ýok.',
+            differentiation: 'aýdyň. Ojaklaýyn üýtgemeleri bellenmeýär.',
+            heterotopia: 'bellenmeýar.',
+            hippocampusSymmetry: 'Simmetrik.',
+            hippocampusLesions: 'ojaklaýyn üýtgeşme ýok.',
+            parenchymaChanges: 'Beýni parenhimasynyň ojaklaýyn üýtgemeleri anyklanmaýar. Geterotopiýa ýok. Gippokamp simmetrik.',
+            liquorSpaces: 'Beýni garynjyklary giňelmedik, bazal sisternalar we konweksital subarahnoidal keşler kadaly.',
+            conclusion: 'Kelle beýnide anyk organiki üýtgeşme ýok.',
+            advice: 'Profilaktiki gözegçilik: kliniki dinamika boýunça baryp görmek.',
+            doctor: 'Döwletow M.M.',
+        },
+        vascular: {
+            date: new Date().toISOString().split('T')[0],
+            patientName: 'Gurbanowa Aýperi',
+            department: 'Nevrologiýa',
+            gender: 'Aýal',
+            birthYear: '1964',
+            patientCode: 'NV-45-219',
+            methods: ['T1', 'T2', 'T2_tirm', 'Diffuz', 'FLAIR', 'MRT angiografiýa'],
+            researchFrequency: 'Ilkinji gezek.',
+            artifactNotes: 'Artefaktlar ýok.',
+            slicePlanes: 'tra, sag, cor; ADC kartasy goşuldy.',
+            skullShape: 'Mezosefal tipli.',
+            cranialSutures: 'kadaly ýagdaýda.',
+            skullSymmetry: 'Simmetrik.',
+            cranialFossa: 'Kadaly.',
+            postoperativeChanges: 'ýok.',
+            differentiation: 'aýdyň, ýagny ak we çal madanyň arasy saýgarlanýar.',
+            heterotopia: 'bellenmeýar.',
+            hippocampusSymmetry: 'Simmetrik.',
+            hippocampusLesions: 'ojaklaýyn üýtgeşme ýok.',
+            parenchymaChanges: 'Periwentrikulýar we subkortikal ak maddada köpetäk mikrouçlar (Fazekas 1-2), täze diffuz ojak ýok.',
+            liquorSpaces: 'Garynjyklar dürli galyňlykda giňelmedik, bazal sisternalar açyk. Subarahnoidal giňişlikler simmetrik.',
+            conclusion: 'Diskirkulýator leýkoentsefalopatiýanyň MRI alamatlary (Fazekas 1-2). Täze ishemiki ojak anyklanmady.',
+            advice: 'Kandaky bosglaryň koreksiýasy, aspirin boýunça maslahat üçin nevrolog.',
+            doctor: 'Atabaýew R.S.',
+        },
+        postop: {
+            date: new Date().toISOString().split('T')[0],
+            patientName: 'Hudainazarow Nurgeldi',
+            department: 'Neýrohirurgiýa',
+            gender: 'Erkek',
+            birthYear: '1982',
+            patientCode: 'OP-308/23',
+            methods: ['T1', 'T2', 'Diffuz', 'FLAIR', 'MRT angiografiýa'],
+            researchFrequency: 'Gaýtadan.',
+            artifactNotes: 'Metal artefaktlar.',
+            slicePlanes: 'tra, sag, cor; operasiýa meýdançasyna inçe kesimler.',
+            skullShape: 'Brahiosefal tipli.',
+            cranialSutures: 'kraniostenoz alamatlary.',
+            skullSymmetry: 'Asimmetrik.',
+            cranialFossa: 'Giňelen.',
+            postoperativeChanges: 'Kraniotomiýa.',
+            differentiation: 'aýdyň, operasiýa meýdançasynyň töwereginde gliozly zolaklar.',
+            heterotopia: 'bellenmeýar.',
+            hippocampusSymmetry: 'Asimmetrik.',
+            hippocampusLesions: 'ojaklaýyn üýtgeşme bar.',
+            parenchymaChanges: 'Operasiýa meýdançasynda gliozly zolak, perifokal şişsiz. Rezeksiýa kanalynyň ugry boýunça T2 gadjeti ýokarlanýar.',
+            liquorSpaces: 'Postoperasion döwürde ýerli giňelme we ventriculomegaliýa alamatlary ýok.',
+            conclusion: 'Postoperasion ýagdaý: rezeksiýa meýdançasynyň gliozy, täze göwrümli döreme ýa ganakma alamaty ýok.',
+            advice: 'Kontrol MRT 6 aýdan, neuro-onkolog maslahatyny dowam etdiriň.',
+            doctor: 'Aşykow J.J.',
+        },
+    };
+
+    const template = profiles[profile];
+    if (!template) {
+        showError('Profil tapylmady. Gaýtadan saýlap görüň.');
+        return;
+    }
+
+    Object.entries(template).forEach(([key, value]) => {
+        switch (key) {
+            case 'methods':
+                document.querySelectorAll('input[name="method"]').forEach(input => {
+                    input.checked = value.includes(input.value);
+                });
+                break;
+            case 'gender': {
+                const genderInput = document.querySelector(`input[name="gender"][value="${value}"]`);
+                if (genderInput) genderInput.checked = true;
+                break;
+            }
+            case 'parenchymaChanges':
+            case 'liquorSpaces':
+            case 'conclusion':
+            case 'advice':
+            case 'patientName':
+            case 'department':
+            case 'birthYear':
+            case 'patientCode':
+            case 'slicePlanes':
+            case 'skullShape':
+            case 'cranialSutures':
+            case 'skullSymmetry':
+            case 'cranialFossa':
+            case 'postoperativeChanges':
+            case 'differentiation':
+            case 'heterotopia':
+            case 'hippocampusSymmetry':
+            case 'hippocampusLesions':
+            case 'researchFrequency':
+            case 'artifactNotes':
+            case 'doctor':
+            case 'date':
+                setFieldValue(key, value);
+                break;
+            default:
+                break;
+        }
+    });
+
+    showSuccess('Profil boýunça meýdançalar awtomatiki dolduryldy.');
+}
+
+function setFieldValue(key, value) {
+    const fieldMap = {
+        date: 'research-date',
+        patientName: 'patient-name',
+        department: 'department',
+        birthYear: 'birth-year',
+        patientCode: 'patient-code',
+        researchFrequency: 'research-frequency',
+        artifactNotes: 'artifact-notes',
+        slicePlanes: 'slice-planes',
+        skullShape: 'skull-shape',
+        cranialSutures: 'cranial-sutures',
+        skullSymmetry: 'skull-symmetry',
+        cranialFossa: 'cranial-fossa',
+        postoperativeChanges: 'postoperative-changes',
+        differentiation: 'differentiation',
+        heterotopia: 'heterotopia',
+        hippocampusSymmetry: 'hippocampus-symmetry',
+        hippocampusLesions: 'hippocampus-lesions',
+        parenchymaChanges: 'parenchyma-changes',
+        liquorSpaces: 'liquor-spaces',
+        conclusion: 'conclusion',
+        advice: 'advice',
+        doctor: 'doctor',
+    };
+
+    const elementId = fieldMap[key];
+    if (!elementId) return;
+
+    const element = document.getElementById(elementId);
+    if (element) {
+        element.value = value;
+    }
 }
 
 async function copyReport() {

--- a/styles.css
+++ b/styles.css
@@ -64,6 +64,12 @@ p {
     align-items: center;
 }
 
+.brand-text {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
 .rsna-mark {
     background: var(--rsna-navy);
     color: #fff;
@@ -81,6 +87,29 @@ p {
     padding: 14px 16px;
     font-size: 14px;
     border: 1px solid var(--rsna-border);
+}
+
+.meta-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 10px;
+    margin-top: 6px;
+}
+
+.meta-chip {
+    padding: 10px 12px;
+    border-radius: 12px;
+    border: 1px dashed var(--rsna-border);
+    background: rgba(245, 247, 251, 0.9);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.meta-label {
+    font-size: 12px;
+    color: var(--text-muted);
+    letter-spacing: 0.02em;
 }
 
 .workspace {
@@ -196,6 +225,62 @@ p {
     flex-direction: column;
     gap: 14px;
     background: linear-gradient(180deg, rgba(245, 247, 251, 0.8), #fff 28%);
+}
+
+.auto-intake {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 18px;
+    border: 1px solid var(--rsna-border);
+    border-radius: 14px;
+    padding: 16px;
+    background: #f7f9fe;
+    box-shadow: var(--shadow-soft);
+}
+
+.auto-meta h3 {
+    margin: 4px 0 8px;
+}
+
+.auto-help {
+    background: #fff;
+    border-radius: 12px;
+    border: 1px solid var(--rsna-border);
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.auto-help ul {
+    margin: 0;
+    padding-left: 18px;
+    color: var(--text-muted);
+}
+
+.intake-controls {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 12px;
+    align-items: center;
+}
+
+.control-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.muted {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.intake-actions {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: flex-start;
 }
 
 .card-section {
@@ -540,6 +625,10 @@ details summary {
     .rsna-hero {
         flex-direction: column;
         align-items: flex-start;
+    }
+
+    .auto-intake {
+        grid-template-columns: 1fr;
     }
 }
 


### PR DESCRIPTION
## Summary
- redesign the MRI report page with richer hero, helper cards, and auto-intake area
- add clinical profile picker with three presets for one-click population
- centralize field value helpers and messaging for smarter autofill workflows

## Testing
- manual: opened http://127.0.0.1:8000 to verify layout and autofill controls


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a9fecba488329929cf05743321c30)