### PR TITLE
Add automated tests for summary rendering

### DIFF
--- a/__tests__/helpers/simpleDom.js
+++ b/__tests__/helpers/simpleDom.js
@@ -1,0 +1,342 @@
+function stripTags(content) {
+  return String(content || '')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+class ClassList {
+  constructor(element) {
+    this.element = element;
+    this.set = new Set();
+  }
+
+  add(...tokens) {
+    tokens.filter(Boolean).forEach(token => this.set.add(token));
+    this._sync();
+  }
+
+  remove(...tokens) {
+    tokens.forEach(token => this.set.delete(token));
+    this._sync();
+  }
+
+  toggle(token, force) {
+    if (force === undefined) {
+      if (this.set.has(token)) {
+        this.set.delete(token);
+        this._sync();
+        return false;
+      }
+      this.set.add(token);
+      this._sync();
+      return true;
+    }
+
+    if (force) {
+      this.set.add(token);
+    } else {
+      this.set.delete(token);
+    }
+    this._sync();
+    return !!force;
+  }
+
+  contains(token) {
+    return this.set.has(token);
+  }
+
+  _sync() {
+    this.element._className = Array.from(this.set).join(' ');
+  }
+}
+
+class Element {
+  constructor(tagName, document) {
+    this.tagName = tagName.toLowerCase();
+    this.document = document;
+    this.attributes = new Map();
+    this.children = [];
+    this.parent = null;
+    this.classList = new ClassList(this);
+    this.dataset = {};
+    this.textContent = '';
+    this._innerHTML = '';
+    this.value = '';
+    this.checked = false;
+    this._listeners = new Map();
+    this._className = '';
+  }
+
+  get id() {
+    return this.attributes.get('id') || '';
+  }
+
+  set id(value) {
+    if (value) {
+      this.attributes.set('id', value);
+      this.document?._registerId(value, this);
+    } else {
+      this.attributes.delete('id');
+    }
+  }
+
+  get className() {
+    return this._className;
+  }
+
+  set className(value) {
+    this.setAttribute('class', value);
+  }
+
+  setAttribute(name, value) {
+    if (name === 'id') {
+      this.id = value;
+      return;
+    }
+
+    if (name === 'class') {
+      this.classList.set = new Set(String(value).split(/\s+/).filter(Boolean));
+      this.classList._sync();
+      return;
+    }
+
+    if (name === 'value') {
+      this.value = String(value);
+    }
+
+    this.attributes.set(name, String(value));
+  }
+
+  getAttribute(name) {
+    if (name === 'class') {
+      return this._className;
+    }
+    return this.attributes.has(name) ? this.attributes.get(name) : null;
+  }
+
+  hasAttribute(name) {
+    if (name === 'class') {
+      return this._className.length > 0;
+    }
+    return this.attributes.has(name);
+  }
+
+  removeAttribute(name) {
+    if (name === 'id') {
+      this.id = '';
+      return;
+    }
+    if (name === 'class') {
+      this.classList.set.clear();
+      this.classList._sync();
+      return;
+    }
+    this.attributes.delete(name);
+  }
+
+  toggleAttribute(name, force) {
+    if (force === undefined) {
+      if (this.hasAttribute(name)) {
+        this.removeAttribute(name);
+        return false;
+      }
+      this.setAttribute(name, '');
+      return true;
+    }
+
+    if (force) {
+      this.setAttribute(name, '');
+    } else {
+      this.removeAttribute(name);
+    }
+    return !!force;
+  }
+
+  appendChild(child) {
+    child.parent = this;
+    this.children.push(child);
+    return child;
+  }
+
+  prepend(child) {
+    child.parent = this;
+    this.children.unshift(child);
+    return child;
+  }
+
+  addEventListener(event, handler) {
+    if (!this._listeners.has(event)) {
+      this._listeners.set(event, []);
+    }
+    this._listeners.get(event).push(handler);
+  }
+
+  dispatchEvent(event) {
+    const listeners = this._listeners.get(event.type) || [];
+    listeners.forEach(listener => listener(event));
+  }
+
+  focus() {
+    // no-op for tests
+  }
+
+  select() {
+    // stub for textarea selections
+  }
+
+  closest(selector) {
+    let current = this;
+    while (current) {
+      if (current._matches(selector)) return current;
+      current = current.parent;
+    }
+    return null;
+  }
+
+  querySelectorAll(selector) {
+    const matches = [];
+    for (const child of this.children) {
+      if (child._matches(selector)) {
+        matches.push(child);
+      }
+      matches.push(...child.querySelectorAll(selector));
+    }
+    return matches;
+  }
+
+  querySelector(selector) {
+    for (const child of this.children) {
+      if (child._matches(selector)) {
+        return child;
+      }
+      const nested = child.querySelector(selector);
+      if (nested) return nested;
+    }
+    return null;
+  }
+
+  _matches(selector) {
+    const trimmed = selector.trim();
+
+    if (trimmed.includes(',')) {
+      return trimmed.split(',').some(part => this._matches(part));
+    }
+
+    if (trimmed.endsWith(':checked')) {
+      const baseSelector = trimmed.replace(':checked', '');
+      return this._matches(baseSelector) && !!this.checked;
+    }
+
+    if (trimmed.startsWith('.')) {
+      const classes = trimmed
+        .slice(1)
+        .split('.')
+        .filter(Boolean);
+
+      return classes.every(cls => this.classList.contains(cls));
+    }
+
+    if (trimmed.startsWith('#')) {
+      return this.id === trimmed.slice(1);
+    }
+
+    const attributeMatch = trimmed.match(/^([a-z0-9_-]+)?\[([^=\]]+)(="?([^\]"]+)"?)?\]$/i);
+    if (attributeMatch) {
+      const [, tag, attr, , value] = attributeMatch;
+      if (tag && this.tagName !== tag.toLowerCase()) return false;
+      const currentValue = this.getAttribute(attr);
+      if (value === undefined) return currentValue !== null;
+      return currentValue === value;
+    }
+
+    return this.tagName === trimmed.toLowerCase();
+  }
+
+  get innerHTML() {
+    if (this.children.length) {
+      return this.children.map(child => child.outerHTML || child.innerHTML || '').join('');
+    }
+    return this._innerHTML || '';
+  }
+
+  set innerHTML(value) {
+    this.children = [];
+    this._innerHTML = String(value);
+    this.textContent = stripTags(value);
+  }
+
+  get innerText() {
+    if (this.children.length) {
+      return this.children.map(child => child.innerText).join('');
+    }
+    return stripTags(this._innerHTML || this.textContent);
+  }
+
+  get outerHTML() {
+    const attrs = [];
+    if (this.id) attrs.push(`id="${this.id}"`);
+    if (this.className) attrs.push(`class="${this.className}"`);
+    for (const [key, value] of this.attributes.entries()) {
+      if (key === 'id' || key === 'class') continue;
+      attrs.push(`${key}="${value}"`);
+    }
+    const open = `<${this.tagName}${attrs.length ? ' ' + attrs.join(' ') : ''}>`;
+    const content = this.children.length ? this.children.map(child => child.outerHTML || child.innerHTML).join('') : this._innerHTML || this.textContent;
+    return `${open}${content}</${this.tagName}>`;
+  }
+}
+
+class Document extends Element {
+  constructor() {
+    super('document', null);
+    this.document = this;
+    this.body = new Element('body', this);
+    this._idMap = new Map();
+    this._listeners = new Map();
+  }
+
+  createElement(tag) {
+    return new Element(tag, this);
+  }
+
+  getElementById(id) {
+    return this._idMap.get(id) || null;
+  }
+
+  _registerId(id, element) {
+    this._idMap.set(id, element);
+  }
+
+  addEventListener(event, handler) {
+    if (!this._listeners.has(event)) {
+      this._listeners.set(event, []);
+    }
+    this._listeners.get(event).push(handler);
+  }
+
+  dispatchEvent(event) {
+    const listeners = this._listeners.get(event.type) || [];
+    listeners.forEach(listener => listener(event));
+  }
+
+  querySelectorAll(selector) {
+    return this.body.querySelectorAll(selector);
+  }
+
+  querySelector(selector) {
+    return this.body.querySelector(selector);
+  }
+
+  execCommand() {
+    // noop for legacy copy fallback
+  }
+}
+
+function createTestDOM() {
+  const document = new Document();
+  const window = { document };
+  return { document, window };
+}
+
+module.exports = { createTestDOM, Element, Document };

--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -1,0 +1,197 @@
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('assert');
+const { createTestDOM } = require('./helpers/simpleDom');
+
+function setupForm(document) {
+  const form = document.createElement('form');
+  form.id = 'research-form';
+  document.body.appendChild(form);
+
+  const result = document.createElement('div');
+  result.id = 'result';
+  document.body.appendChild(result);
+
+  const copyButton = document.createElement('button');
+  copyButton.id = 'copyReport';
+  copyButton.disabled = true;
+  document.body.appendChild(copyButton);
+
+  const templateButton = document.createElement('button');
+  templateButton.id = 'fillTemplate';
+  document.body.appendChild(templateButton);
+
+  const profilePicker = document.createElement('select');
+  profilePicker.id = 'profile-picker';
+  document.body.appendChild(profilePicker);
+
+  const applyProfileButton = document.createElement('button');
+  applyProfileButton.id = 'applyProfile';
+  document.body.appendChild(applyProfileButton);
+
+  const profileNote = document.createElement('div');
+  profileNote.id = 'profile-note';
+  document.body.appendChild(profileNote);
+
+  const fields = [
+    'research-date',
+    'patient-name',
+    'department',
+    'birth-year',
+    'patient-code',
+    'research-frequency',
+    'artifact-notes',
+    'skull-shape',
+    'cranial-sutures',
+    'skull-symmetry',
+    'cranial-fossa',
+    'postoperative-changes',
+    'differentiation',
+    'heterotopia',
+    'hippocampus-symmetry',
+    'hippocampus-lesions',
+    'slice-planes',
+    'parenchyma-changes',
+    'liquor-spaces',
+    'conclusion',
+    'advice',
+    'doctor',
+  ];
+
+  fields.forEach(id => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'field-group';
+    const input = document.createElement('input');
+    input.id = id;
+    wrapper.appendChild(input);
+    form.appendChild(wrapper);
+  });
+
+  const genderWrapper = document.createElement('div');
+  const male = document.createElement('input');
+  male.setAttribute('type', 'radio');
+  male.setAttribute('name', 'gender');
+  male.setAttribute('value', 'Erkek');
+  male.value = 'Erkek';
+  const female = document.createElement('input');
+  female.setAttribute('type', 'radio');
+  female.setAttribute('name', 'gender');
+  female.setAttribute('value', 'Aýal');
+  female.value = 'Aýal';
+  genderWrapper.appendChild(male);
+  genderWrapper.appendChild(female);
+  form.appendChild(genderWrapper);
+
+  const methodOne = document.createElement('input');
+  methodOne.setAttribute('type', 'checkbox');
+  methodOne.setAttribute('name', 'method');
+  methodOne.value = 'Umumy';
+  const methodTwo = document.createElement('input');
+  methodTwo.setAttribute('type', 'checkbox');
+  methodTwo.setAttribute('name', 'method');
+  methodTwo.value = 'T1';
+  form.appendChild(methodOne);
+  form.appendChild(methodTwo);
+}
+
+function fillRequiredFields(document) {
+  document.getElementById('research-date').value = '2025-12-11';
+  document.getElementById('patient-name').value = 'Amanow Aman';
+  document.getElementById('department').value = 'Nevrologiýa';
+  document.getElementById('birth-year').value = '1990';
+  document.getElementById('patient-code').value = 'ABC-123';
+  document.getElementById('research-frequency').value = 'Ilkinji gezek.';
+  document.getElementById('artifact-notes').value = 'Artefaktlar ýok.';
+  document.getElementById('skull-shape').value = 'Mezosefal tipli.';
+  document.getElementById('cranial-sutures').value = 'kadaly ýagdaýda.';
+  document.getElementById('skull-symmetry').value = 'Simmetrik.';
+  document.getElementById('cranial-fossa').value = 'Kadaly.';
+  document.getElementById('postoperative-changes').value = 'ýok.';
+  document.getElementById('differentiation').value = 'aýdyň.';
+  document.getElementById('heterotopia').value = 'bellenmeýar.';
+  document.getElementById('hippocampus-symmetry').value = 'Simmetrik.';
+  document.getElementById('hippocampus-lesions').value = 'ojak ýok.';
+  document.getElementById('slice-planes').value = 'tra, sag, cor kesimlerde';
+  document.getElementById('parenchyma-changes').value = 'Üýtgeşme anyklanmaýar';
+  document.getElementById('liquor-spaces').value = 'Kadaly giňişlikler';
+  document.getElementById('conclusion').value = 'Netije ýazgysy';
+  document.getElementById('advice').value = 'Maslahat ýazgysy';
+  document.getElementById('doctor').value = 'Lukman';
+
+  const gender = document.querySelector('input[name="gender"]');
+  if (gender) {
+    gender.checked = true;
+  }
+
+  const method = document.querySelector('input[name="method"]');
+  if (method) {
+    method.checked = true;
+  }
+}
+
+function loadScript() {
+  delete require.cache[require.resolve('../script')];
+  return require('../script');
+}
+
+describe('renderSummary and copyReport', () => {
+  let document;
+  let window;
+  let script;
+
+  beforeEach(() => {
+    ({ document, window } = createTestDOM());
+    global.document = document;
+    global.window = window;
+    global.navigator = { clipboard: { writeText: async () => {} } };
+
+    setupForm(document);
+    script = loadScript();
+  });
+
+  it('marks missing required fields and avoids rendering a summary', () => {
+    const copyButton = document.getElementById('copyReport');
+    copyButton.disabled = true;
+
+    script.renderSummary();
+
+    const errorFields = document.querySelectorAll('.field-error');
+    assert.ok(errorFields.length >= 8, 'Required fields should be marked as errors');
+
+    const ariaInvalid = document.querySelectorAll('[aria-invalid="true"]');
+    assert.ok(ariaInvalid.length >= 7, 'Inputs should include aria-invalid for missing values');
+
+    const resultContainer = document.getElementById('result');
+    assert.strictEqual(resultContainer.innerHTML, '');
+    assert.strictEqual(copyButton.disabled, true);
+
+    const messages = document.querySelectorAll('.message.error');
+    assert.ok(messages.length > 0, 'Error message should be displayed');
+  });
+
+  it('renders summary and copies the report when fields are filled', async () => {
+    fillRequiredFields(document);
+    const copyButton = document.getElementById('copyReport');
+    copyButton.disabled = true;
+
+    script.renderSummary();
+
+    const resultContainer = document.getElementById('result');
+    assert.ok(resultContainer.innerHTML.includes('Umumy maglumatlar'));
+    assert.strictEqual(copyButton.disabled, false);
+
+    let copiedText = '';
+    global.navigator.clipboard = {
+      writeText: async text => {
+        copiedText = text;
+      },
+    };
+
+    await script.copyReport();
+
+    assert.ok(copiedText.includes('Amanow Aman'));
+    assert.ok(copiedText.includes('Netije ýazgysy'));
+
+    const successMessages = document.querySelectorAll('.message.success');
+    assert.ok(successMessages.length > 0, 'Copy success message should be shown');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "mri",
+  "version": "1.0.0",
+  "description": "The site is a single-page Turkmen-language MRI reporting helper built from index.html, styles.css, script.js, and saveWord.js, with FileSaver loaded from a CDN for downloads. The export workflow now feeds collected values into the bundled Beýni_kada_.docx template through PizZip + Docxtemplater for true .docx output.",
+  "main": "FileSaver.min.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/script.js
+++ b/script.js
@@ -631,3 +631,14 @@ async function copyReport() {
         showError('Hasabaty göçürip bolmady: ' + error.message);
     }
 }
+
+if (typeof module !== 'undefined') {
+    module.exports = {
+        renderSummary,
+        copyReport,
+        ensureMessageContainer,
+        clearMessages,
+        resetValidationState,
+        markInvalid,
+    };
+}


### PR DESCRIPTION
## Summary
- add a Node-based test script and lightweight DOM utilities to exercise the form summary logic
- export browser functions from the main script for reuse in tests
- cover both validation and successful rendering/copy scenarios for the report

## Testing
- node --test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aa8fc52d48329adbb39783b0c8f97)