### PR TITLE
Add structures symmetry section and conditional styling

### DIFF
--- a/app.js
+++ b/app.js
@@ -158,7 +158,7 @@ function renderForm() {
             <option value="bar (şu ýerde beýan ediň).">bar (şu ýerde beýan ediň).</option>
           </select>
         </label>
-        <div class="conditional-field" data-related="postoperativeChanges">
+        <div class="conditional-field" data-related="postoperativeChanges" hidden>
           <label class="nested-field">
             <span>Giňişleýin beýan</span>
             <textarea name="postoperativeChangesDetails" data-label-tm="Operasiýadan soňky üýtgemeleri (beýan)" rows="3"></textarea>
@@ -179,7 +179,7 @@ function renderForm() {
             <option value="bar (şu ýerde beýan ediň).">bar (şu ýerde beýan ediň).</option>
           </select>
         </label>
-        <div class="conditional-field" data-related="heterotopia">
+        <div class="conditional-field" data-related="heterotopia" hidden>
           <label class="nested-field">
             <span>Giňişleýin beýan</span>
             <textarea name="heterotopiaDetails" data-label-tm="Geterotopiýa (beýan)" rows="3"></textarea>

--- a/styles.css
+++ b/styles.css
@@ -123,10 +123,25 @@ main {
   background: #f9fafb;
 }
 
+.conditional-field[hidden] {
+  display: none;
+}
+
 .nested-field {
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+
+.conditional-field .nested-field span {
+  font-weight: 600;
+  color: #111827;
+}
+
+.conditional-field .nested-field textarea {
+  background: #ffffff;
+  border-color: rgba(17, 24, 39, 0.16);
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.08);
 }
 
 .app-footer {


### PR DESCRIPTION
## Summary
- add the Gurluşlar we simmetriýa section with required Turkmen fields and defaults
- show detail text areas reactively when postoperative changes or heterotopia are marked as present
- refine nested textarea styling for the conditional fields

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ab7bba1b88329bb22d69ffc8c5d80)