### PR TITLE
Add autosave draft support

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -55,6 +55,25 @@ main {
   box-shadow: 0 10px 30px rgba(17, 24, 39, 0.05);
 }
 
+.draft-status {
+  margin: 0 0 16px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(59, 130, 246, 0.08);
+  color: #1d4ed8;
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.draft-status.is-restored {
+  background: rgba(16, 185, 129, 0.1);
+  border-color: rgba(16, 185, 129, 0.35);
+  color: #047857;
+}
+
 .card {
   background: #ffffff;
   border: 1px solid rgba(0, 0, 0, 0.04);


### PR DESCRIPTION
## Summary
- add localStorage-based draft autosave with restore prompt
- add reset action and draft status banner for the report form

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693abfcdd14c8329baa503014de11c05)