### PR TITLE
Improve RSNA report builder architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Static single-page RSNA MRI report studio built for GitHub Pages with vanilla HT
 - `index.html` – Page shell (header/main/footer), mounts the form into `#app` and shows preview in `#reportPreview`.
 - `styles.css` – Base layout and card styling for form sections and preview.
 - `app.js` – Entry point; initializes state from localStorage, renders the UI shell, attaches event handlers, and wires buttons for generate/clear/export.
-- `schema.js` – Declarative RSNA/022 section and field definitions (ids, labels, input types, options).
+- `schema.js` – Declarative RSNA/022 section and field definitions (ids, labels, input types, options) + `createEmptyReportState()` helper.
 - `profiles.js` – Clinical profile presets (kadaly, dyscirculatory, postoperative) with default field values.
-- `state.js` – Lightweight observable store for `reportState` with `init`, `setField`, and subscriptions.
+- `state.js` – Lightweight observable store for `reportState` with `init`, `setField`, dirtiness check, and subscriptions.
 - `renderForm.js` – Renders form sections based on `schema.js`, binds input events to `reportState` updates.
-- `report.js` – Assembles Turkmen plain-text report blocks per section, skipping empty fields.
+- `report.js` – Assembles Turkmen plain-text report blocks per section, skipping empty fields; exports reusable blocks for previews/exports.
 - `storage.js` – Draft persistence helpers for autosave/restore via `localStorage`.
 - `i18n.js` – Minimal translation helper for UI labels (TM-first, extensible to RU/EN).
-- `exportDocx.js` – Placeholder for future docxtemplater-based DOCX export flow.
+- `exportDocx.js` – Generates a Word-compatible `.doc` download from the structured report.
 
 ## Usage
 Open `index.html` on GitHub Pages or a static server. Select a clinical profile to prefill defaults, complete the generated form, and click **Hasabat döret** to view the structured text in the preview panel. Drafts save automatically between sessions; **Arassala / täzele** clears state and storage. DOCX export is stubbed until docxtemplater wiring is added.

--- a/app.js
+++ b/app.js
@@ -4,20 +4,39 @@
 import { CLINICAL_PROFILES } from "./profiles.js";
 import { reportState } from "./state.js";
 import { renderForm } from "./renderForm.js";
-import { generatePlainTextReport } from "./report.js";
+import { buildReportBlocks, generatePlainTextReport } from "./report.js";
 import { loadDraft, saveDraft, clearDraft } from "./storage.js";
 import { translate } from "./i18n.js";
 import { exportToDocx } from "./exportDocx.js";
+import { SECTIONS, createEmptyReportState } from "./schema.js";
 
 const appRoot = document.getElementById("app");
 const previewSection = document.getElementById("reportPreview");
 const previewContent = document.getElementById("reportPreviewContent");
+let profileDescriptionEl = null;
+
+function renderProfileDescription(profile) {
+  if (!profileDescriptionEl) {
+    profileDescriptionEl = document.getElementById("profileDescription");
+  }
+  if (!profileDescriptionEl) return;
+  if (!profile) {
+    profileDescriptionEl.textContent = "Profil saýlanmady.";
+    return;
+  }
+  profileDescriptionEl.textContent = profile.description || "Deslapky dolduryş gurnalan profil.";
+}
 
 function applyProfileDefaults(profileId) {
   const profile = CLINICAL_PROFILES[profileId];
   if (!profile) return;
+  if (reportState.isDirty()) {
+    const confirmed = window.confirm("Saýlanan profil häzirki maglumatlary üýtgedip biler. Dowam etmelimi?");
+    if (!confirmed) return;
+  }
   Object.entries(profile.defaults).forEach(([key, value]) => reportState.setField(key, value));
   renderForm(document.getElementById("formContainer"));
+  renderProfileDescription(profile);
 }
 
 function renderShell() {
@@ -35,14 +54,19 @@ function renderShell() {
                 .map((profile) => `<option value="${profile.id}">${profile.label}</option>`)
                 .join("")}
             </select>
+            <p id="profileDescription" class="profile-description">Profil saýlanmady.</p>
           </div>
         </div>
       </div>
       <div id="formContainer"></div>
+      <div id="validationNotice" class="notice" hidden>
+        <strong>Gerekli meýdançalar doldurylyp bilinmedi.</strong>
+        <span class="notice__text"></span>
+      </div>
       <div class="actions">
         <button id="btn-generate">Hasabat döret</button>
         <button id="btn-clear" type="button">Arassala / täzele</button>
-        <button id="btn-export" type="button">DOCX eksporty (draft)</button>
+        <button id="btn-export" type="button">Word eksporty</button>
       </div>
     </section>
   `;
@@ -54,22 +78,27 @@ function attachHandlers() {
     if (profileSelect.value) {
       applyProfileDefaults(profileSelect.value);
     }
+    const selectedProfile = CLINICAL_PROFILES[profileSelect.value];
+    renderProfileDescription(selectedProfile);
   });
 
   const generateBtn = document.getElementById("btn-generate");
   generateBtn?.addEventListener("click", () => {
+    const valid = validateRequiredFields();
     const reportText = generatePlainTextReport(reportState.data);
     if (previewSection && previewContent) {
-      previewContent.textContent = reportText;
-      previewSection.hidden = !reportText;
+      previewContent.textContent = reportText || "Gerekli maglumatlar girizileniňden soň hasabat şu ýerde peýda bolar.";
+      previewSection.hidden = !valid || !reportText;
     }
   });
 
   const clearBtn = document.getElementById("btn-clear");
   clearBtn?.addEventListener("click", () => {
-    reportState.init({});
+    resetValidationState();
+    reportState.init(createEmptyReportState());
     clearDraft();
     renderForm(document.getElementById("formContainer"));
+    renderProfileDescription(null);
     if (previewSection && previewContent) {
       previewContent.textContent = "";
       previewSection.hidden = true;
@@ -78,7 +107,9 @@ function attachHandlers() {
 
   const exportBtn = document.getElementById("btn-export");
   exportBtn?.addEventListener("click", async () => {
-    await exportToDocx(reportState.data);
+    const valid = validateRequiredFields();
+    if (!valid) return;
+    await exportToDocx(reportState.data, buildReportBlocks(reportState.data));
   });
 }
 
@@ -90,12 +121,60 @@ function setupAutosave() {
 
 function init() {
   const draft = loadDraft();
-  reportState.init(draft || {});
+  reportState.init(draft || createEmptyReportState());
 
   renderShell();
   renderForm(document.getElementById("formContainer"));
+  renderProfileDescription(null);
   attachHandlers();
   setupAutosave();
+}
+
+function validateRequiredFields() {
+  resetValidationState();
+  const missing = [];
+  SECTIONS.forEach((section) => {
+    section.fields.forEach((field) => {
+      if (!field.required) return;
+      const value = reportState.getField(field.name);
+      const isEmpty = Array.isArray(value) ? value.length === 0 : !value;
+      const control = document.getElementById(field.name);
+      control?.classList.toggle("input-error", isEmpty);
+      control?.setAttribute("aria-invalid", isEmpty);
+      control?.closest(".form-field")?.classList.toggle("form-field--error", isEmpty);
+      if (isEmpty) {
+        missing.push(field.labelTm);
+      }
+    });
+  });
+
+  const notice = document.getElementById("validationNotice");
+  if (notice) {
+    notice.hidden = missing.length === 0;
+    const text = notice.querySelector(".notice__text");
+    if (text) {
+      text.textContent = missing.length > 0 ? `Dolduryň: ${missing.join(", ")}` : "";
+    }
+  }
+
+  return missing.length === 0;
+}
+
+function resetValidationState() {
+  document.querySelectorAll(".input-error").forEach((el) => {
+    el.classList.remove("input-error");
+    el.removeAttribute("aria-invalid");
+  });
+  document.querySelectorAll(".form-field--error").forEach((el) => {
+    el.classList.remove("form-field--error");
+  });
+
+  const notice = document.getElementById("validationNotice");
+  if (notice) {
+    notice.hidden = true;
+    const text = notice.querySelector(".notice__text");
+    if (text) text.textContent = "";
+  }
 }
 
 init();

--- a/exportDocx.js
+++ b/exportDocx.js
@@ -1,11 +1,67 @@
 // exportDocx.js
-// DOCX eksporty üçin jaý. docxtemplater bilen integrasiýa üçin ýer goýýarys.
-// Häzirki wagtda diňe TODO görnüşinde görkezilýär.
+// Ýönekeý Word (DOC) eksporty: hasabaty HTML görnüşinde ýygnap, .doc görnüşinde ýükleýär.
 
-export async function exportToDocx(reportData) {
-  // TODO: docxtemplater integrasiýasy üçin ýer:
-  // 1) docxtemplater we pizzip/JSZip kitaplaryny <script> arkaly birikdiriň.
-  // 2) Şablon DOCX resminamasyny fetch edip, ýerlikli meýdançalar bilen çalşyň.
-  // 3) saveAs(File) arkaly ulanýjyga ýükle.
-  console.info("DOCX eksporty entek taýýar däl", reportData);
+import { generatePlainTextReport } from "./report.js";
+
+function buildPatientHeader(blocks) {
+  const patientBlock = blocks.find((block) => block.id === "patient");
+  if (!patientBlock) return "";
+  return `<div class="doc-header"><h2>Näsag we barlag</h2><ul>${patientBlock.lines
+    .map((line) => `<li>${line}</li>`)
+    .join("")}</ul></div>`;
+}
+
+export async function exportToDocx(reportData, blocks = []) {
+  const plainText = generatePlainTextReport(reportData);
+  if (!plainText) {
+    alert("Ilki bilen gerekli meýdançalary dolduryň we hasabat dörediň.");
+    return;
+  }
+
+  const sectionBlocks = blocks.length > 0 ? blocks : [];
+  const patientHeader = buildPatientHeader(sectionBlocks);
+  const otherSections = sectionBlocks
+    .filter((block) => block.id !== "patient")
+    .map(
+      (block) => `
+        <section class="doc-section">
+          <h3>${block.heading}</h3>
+          <ul>
+            ${block.lines.map((line) => `<li>${line}</li>`).join("")}
+          </ul>
+        </section>`
+    )
+    .join("\n");
+
+  const html = `
+    <html>
+      <head>
+        <meta charset="UTF-8" />
+        <style>
+          body { font-family: Arial, sans-serif; line-height: 1.5; }
+          h1 { text-align: center; }
+          h2, h3 { margin-bottom: 6px; }
+          ul { padding-left: 18px; }
+          .doc-section { margin-bottom: 10px; }
+          .doc-header { border-bottom: 1px solid #ccc; margin-bottom: 12px; padding-bottom: 6px; }
+        </style>
+      </head>
+      <body>
+        <h1>RSNA/022 beýni MRT hasabaty</h1>
+        ${patientHeader}
+        ${otherSections}
+      </body>
+    </html>
+  `;
+
+  const blob = new Blob([html], { type: "application/msword" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  const filename = `rsna-mri-${reportData.patient_name || "hasabat"}.doc`;
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
 }

--- a/i18n.js
+++ b/i18n.js
@@ -3,7 +3,7 @@
 
 const DICTIONARY = {
   tm: {
-    "section.general": "Umumy maglumatlar",
+    "section.patient": "Näsag / barlag maglumatlary",
     "section.flow": "Barlag akymy",
     "section.structures": "Gurluşlar we simmetriýa",
     "section.result": "Netije",

--- a/profiles.js
+++ b/profiles.js
@@ -6,6 +6,7 @@ export const CLINICAL_PROFILES = {
   kadaly: {
     id: "kadaly",
     label: "Kadaly MRT (profilaktika)",
+    description: "Pes riskli, şikaýatsyz näsaglar üçin doly barlag sekansiýasy.",
     defaults: {
       exam_types: ["Umumy", "T1", "T2", "T2_tirm", "Diffuz", "MRT angiografiýa"],
       artefacts: "Artefaktlar ýok.",
@@ -13,18 +14,24 @@ export const CLINICAL_PROFILES = {
       skull: "Sütünli gurluş, patologiýa ýok.",
       symmetry: "Orta çyzyk boýunça simmetrik.",
       parenchyma: "Diffuziýa çäklendirilmesi tapylmady.",
+      ventricles: "Wentrikullar giňelmedik, orta çyzyk siljemeýär.",
+      vascular: "Aýdyň patologiýa ýok.",
+      sinuses: "Paranazal sinuslarda patologik sütünlenme ýok.",
     },
   },
   dyscirculatory: {
     id: "dyscirculatory",
     label: "Diskirkulýator",
+    description: "Kislorod ýetmezçiligi bilen baglanyşykly üýtgemeleriň standart beýanlamasy.",
     defaults: {
       parenchyma: "Subkortikal we periwentrikulýar ak maddada beýleki kislorod ýetmezçiligi bilen baglanyşykly üýtgemeler.",
+      vascular: "Aterosklerotik üýtgemeler boýunça goşmaça angiografiýa maslahat berilýär.",
     },
   },
   postoperative: {
     id: "postoperative",
     label: "Operasiýadan soňky",
+    description: "Operasiýadan soňky gözegçilik: kraniotomiýa we operasiýa meýdanyny belläp geçýär.",
     defaults: {
       skull: "Kraniotomiýa yzlary.",
       parenchyma: "Operasiýa meýdanynda glioz/edema gözegçiligi.",

--- a/renderForm.js
+++ b/renderForm.js
@@ -12,6 +12,12 @@ function createField(field) {
   const label = document.createElement("label");
   label.textContent = field.labelTm;
   label.setAttribute("for", field.name);
+  if (field.required) {
+    const mark = document.createElement("span");
+    mark.className = "required-mark";
+    mark.textContent = "*";
+    label.appendChild(mark);
+  }
 
   let control;
   switch (field.type) {
@@ -44,6 +50,10 @@ function createField(field) {
 
   control.id = field.name;
   control.name = field.name;
+  control.required = Boolean(field.required);
+  if (field.placeholder) {
+    control.placeholder = field.placeholder;
+  }
 
   const currentValue = reportState.getField(field.name);
   if (control.multiple && Array.isArray(currentValue)) {
@@ -63,6 +73,12 @@ function createField(field) {
 
   wrapper.appendChild(label);
   wrapper.appendChild(control);
+  if (field.hint) {
+    const hint = document.createElement("p");
+    hint.className = "field-hint";
+    hint.textContent = field.hint;
+    wrapper.appendChild(hint);
+  }
   return wrapper;
 }
 
@@ -87,6 +103,7 @@ function renderSection(section) {
 }
 
 export function renderForm(root) {
+  if (!root) return;
   root.innerHTML = "";
   SECTIONS.forEach((section) => {
     const sectionEl = renderSection(section);

--- a/report.js
+++ b/report.js
@@ -4,7 +4,7 @@
 import { SECTIONS } from "./schema.js";
 
 const SECTION_LABELS = {
-  general: "Umumy maglumatlar:",
+  patient: "Näsag we ugradyş barada:",
   flow: "Barlag akymy:",
   structures: "Gurluşlar we simmetriýa:",
   result: "Netije:",
@@ -14,22 +14,23 @@ const SECTION_LABELS = {
 function formatLine(label, value) {
   if (!value || (Array.isArray(value) && value.length === 0)) return "";
   if (Array.isArray(value)) {
-    return `- ${label} ${value.join(", ")}`;
+    return `- ${label}: ${value.join(", ")}`;
   }
-  return `- ${label} ${value}`;
+  return `- ${label}: ${value}`;
 }
 
-export function generatePlainTextReport(reportData) {
-  const blocks = SECTIONS.map((section) => {
+export function buildReportBlocks(reportData) {
+  return SECTIONS.map((section) => {
     const heading = SECTION_LABELS[section.id] || section.id;
     const lines = section.fields
       .map((field) => formatLine(field.labelTm, reportData[field.name]))
-      .filter(Boolean)
-      .join("\n");
+      .filter(Boolean);
 
-    if (!lines) return "";
-    return `${heading}\n${lines}`;
-  }).filter(Boolean);
+    return { id: section.id, heading, lines };
+  }).filter((block) => block.lines.length > 0);
+}
 
+export function generatePlainTextReport(reportData) {
+  const blocks = buildReportBlocks(reportData).map((block) => `${block.heading}\n${block.lines.join("\n")}`);
   return blocks.join("\n\n");
 }

--- a/schema.js
+++ b/schema.js
@@ -4,15 +4,17 @@
 
 export const SECTIONS = [
   {
-    id: "general",
-    titleKey: "section.general",
+    id: "patient",
+    titleKey: "section.patient",
     fields: [
-      { name: "exam_date", labelTm: "Barlagyň senesi ?", type: "date" },
-      { name: "patient_name", labelTm: "Familiyasy, ady ?", type: "text" },
-      { name: "department", labelTm: "Bölüm ?", type: "text" },
-      { name: "gender", labelTm: "Jynsy", type: "select", options: ["Erkek", "Aýal"] },
-      { name: "birth_year", labelTm: "Doglan ýyly ?", type: "text" },
-      { name: "patient_code", labelTm: "Näsagyň kody ?", type: "text" },
+      { name: "patient_name", labelTm: "Familiýasy, ady", type: "text", required: true },
+      { name: "patient_code", labelTm: "Näsagyň kody / ID", type: "text", required: true },
+      { name: "age", labelTm: "Ýaşy", type: "number", placeholder: "45", required: true },
+      { name: "gender", labelTm: "Jynsy", type: "select", options: ["Erkek", "Aýal"], required: true },
+      { name: "birth_year", labelTm: "Doglan ýyly", type: "number", placeholder: "1975" },
+      { name: "exam_date", labelTm: "Barlagyň senesi", type: "date", required: true },
+      { name: "referrer", labelTm: "Ugratýan lukman", type: "text", placeholder: "Nörolog lukman" },
+      { name: "clinical_note", labelTm: "Kliniki maglumat / ugradyş sebäbi", type: "textarea" },
     ],
   },
   {
@@ -24,9 +26,11 @@ export const SECTIONS = [
         labelTm: "Barlag usuly",
         type: "multiselect",
         options: ["Umumy", "T1", "T2", "T2_tirm", "Diffuz", "MRT angiografiýa"],
+        hint: "Birnäçe sebit/sekansiýany saýlap bilersiňiz",
       },
-      { name: "artefacts", labelTm: "Artefaktlar", type: "textarea" },
-      { name: "slice_plane", labelTm: "Kesim ugry", type: "text" },
+      { name: "artefacts", labelTm: "Artefaktlar", type: "textarea", placeholder: "Artefaktlar ýok" },
+      { name: "slice_plane", labelTm: "Kesim ugry", type: "text", placeholder: "tra, sag, cor kesimlerde" },
+      { name: "contrast", labelTm: "Kontrast ulanmasy", type: "select", options: ["Ulanylmady", "Kontrast berildi"] },
     ],
   },
   {
@@ -36,12 +40,15 @@ export const SECTIONS = [
       { name: "skull", labelTm: "Kelle çanagynyň gurluşy", type: "textarea" },
       { name: "symmetry", labelTm: "Simmetriýa", type: "textarea" },
       { name: "parenchyma", labelTm: "Beýni parenhimasynyň üýtgemeleri", type: "textarea" },
+      { name: "ventricles", labelTm: "Ventrikulýar sistema / Serebrospinal suwuklyk", type: "textarea" },
+      { name: "vascular", labelTm: "Damar gurluşlary", type: "textarea" },
+      { name: "sinuses", labelTm: "Paranazal sinuslar / mastoid", type: "textarea" },
     ],
   },
   {
     id: "result",
     titleKey: "section.result",
-    fields: [{ name: "conclusion", labelTm: "Netije", type: "textarea" }],
+    fields: [{ name: "conclusion", labelTm: "Netije", type: "textarea", required: true }],
   },
   {
     id: "advice",
@@ -51,3 +58,18 @@ export const SECTIONS = [
 ];
 
 export const SECTION_ORDER = SECTIONS.map((section) => section.id);
+
+export function createEmptyReportState() {
+  return SECTIONS.reduce((acc, section) => {
+    section.fields.forEach((field) => {
+      const defaultValue =
+        field.defaultValue !== undefined
+          ? field.defaultValue
+          : field.type === "multiselect"
+          ? []
+          : "";
+      acc[field.name] = defaultValue;
+    });
+    return acc;
+  }, {});
+}

--- a/state.js
+++ b/state.js
@@ -1,13 +1,17 @@
 // state.js
 // Ýönekeý observable görnüşli state dolandyryşy. reportState data modelini saklaýar.
 
+import { createEmptyReportState } from "./schema.js";
+
 const listeners = [];
 
 export const reportState = {
-  data: {},
+  data: createEmptyReportState(),
+  baseState: createEmptyReportState(),
 
   init(initialData = {}) {
-    this.data = { ...initialData };
+    this.baseState = createEmptyReportState();
+    this.data = { ...this.baseState, ...initialData };
     this.notify();
   },
 
@@ -18,6 +22,16 @@ export const reportState = {
 
   getField(name) {
     return this.data[name];
+  },
+
+  isDirty() {
+    return Object.entries(this.data).some(([key, value]) => {
+      const baseValue = this.baseState[key];
+      if (Array.isArray(value)) {
+        return value.length > 0 && JSON.stringify(value) !== JSON.stringify(baseValue || []);
+      }
+      return value !== baseValue && value !== "" && value !== null && value !== undefined;
+    });
   },
 
   subscribe(listener) {

--- a/styles.css
+++ b/styles.css
@@ -86,6 +86,17 @@ main {
   color: #1f2937;
 }
 
+.required-mark {
+  color: #ef4444;
+  margin-left: 6px;
+}
+
+.field-hint {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
 .form-field input,
 .form-field textarea,
 .form-field select {
@@ -102,11 +113,39 @@ main {
   resize: vertical;
 }
 
+.form-field--error label {
+  color: #b91c1c;
+}
+
+.input-error {
+  border-color: rgba(239, 68, 68, 0.7);
+  background: #fff5f5;
+}
+
 .actions {
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
   margin-top: 8px;
+}
+
+.notice {
+  background: #fff3cd;
+  color: #7c4b00;
+  border: 1px solid #fcd34d;
+  padding: 12px 14px;
+  border-radius: 10px;
+  margin: 12px 0;
+}
+
+.notice strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.profile-description {
+  margin: 6px 0 0;
+  color: #475569;
 }
 
 button {


### PR DESCRIPTION
## Summary
- add structured patient/exam schema defaults and expose helper to seed state cleanly
- render required field cues with validation banner, profile descriptions, and safer preset application
- refactor report generation into reusable blocks and implement Word-compatible export plus styling updates

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693af062d90083299a29824bed3df39c)