### PR TITLE
Add Electron SQLite skeleton for RSNA MRI app

### DIFF
--- a/mri-report-app/db.js
+++ b/mri-report-app/db.js
@@ -1,0 +1,107 @@
+const Database = require("better-sqlite3");
+const path = require("path");
+const fs = require("fs");
+
+const dbPath = path.join(__dirname, "mri_reports.db");
+let db;
+
+function initDb() {
+  db = new Database(dbPath);
+  const initSql = fs.readFileSync(path.join(__dirname, "sql", "init.sql"), "utf8");
+  db.exec(initSql);
+}
+
+function savePatient(patient) {
+  const stmt = db.prepare(
+    `INSERT INTO patients (full_name, birth_date, gender, hospital_id)
+     VALUES (@full_name, @birth_date, @gender, @hospital_id)`
+  );
+  const info = stmt.run(patient);
+  return info.lastInsertRowid;
+}
+
+function saveStudy(study) {
+  const stmt = db.prepare(
+    `INSERT INTO studies (patient_id, study_date, modality, region, ref_physician, clinical_info, is_followup, prev_study_date)
+     VALUES (@patient_id, @study_date, @modality, @region, @ref_physician, @clinical_info, @is_followup, @prev_study_date)`
+  );
+  const info = stmt.run(study);
+  return info.lastInsertRowid;
+}
+
+function saveBrainReport(report) {
+  const stmt = db.prepare(
+    `INSERT INTO brain_mri_reports (
+      study_id,
+      artefacts_type,
+      skull_shape,
+      skull_sutures,
+      skull_form_symmetry,
+      posterior_fossa,
+      lesions_ischemic,
+      lesions_hemorrhagic,
+      lesions_demyelinating,
+      lesions_number,
+      lesions_location,
+      lesions_size,
+      cysts_info,
+      mass_info,
+      ventricles_info,
+      cisterns_info,
+      subarachnoid_info,
+      pituitary_info,
+      orbit_info,
+      temporal_bone_info,
+      cranial_nerves_info,
+      angio_info,
+      conclusion,
+      recommendations
+    ) VALUES (
+      @study_id,
+      @artefacts_type,
+      @skull_shape,
+      @skull_sutures,
+      @skull_form_symmetry,
+      @posterior_fossa,
+      @lesions_ischemic,
+      @lesions_hemorrhagic,
+      @lesions_demyelinating,
+      @lesions_number,
+      @lesions_location,
+      @lesions_size,
+      @cysts_info,
+      @mass_info,
+      @ventricles_info,
+      @cisterns_info,
+      @subarachnoid_info,
+      @pituitary_info,
+      @orbit_info,
+      @temporal_bone_info,
+      @cranial_nerves_info,
+      @angio_info,
+      @conclusion,
+      @recommendations
+    )`
+  );
+  const info = stmt.run(report);
+  return info.lastInsertRowid;
+}
+
+function listPatients() {
+  return db.prepare("SELECT * FROM patients ORDER BY id DESC").all();
+}
+
+function listStudies(patientId) {
+  return db
+    .prepare("SELECT * FROM studies WHERE patient_id = @patientId ORDER BY study_date DESC")
+    .all({ patientId });
+}
+
+module.exports = {
+  initDb,
+  savePatient,
+  saveStudy,
+  saveBrainReport,
+  listPatients,
+  listStudies,
+};

--- a/mri-report-app/main.js
+++ b/mri-report-app/main.js
@@ -1,0 +1,40 @@
+const { app, BrowserWindow, ipcMain } = require("electron");
+const path = require("path");
+const db = require("./db");
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1280,
+    height: 900,
+    webPreferences: {
+      preload: path.join(__dirname, "renderer", "preload.js"),
+      contextIsolation: true,
+    },
+  });
+
+  win.loadFile(path.join(__dirname, "renderer", "index.html"));
+}
+
+app.whenReady().then(() => {
+  db.initDb();
+  createWindow();
+
+  app.on("activate", () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") {
+    app.quit();
+  }
+});
+
+ipcMain.handle("patients:save", (event, patient) => db.savePatient(patient));
+ipcMain.handle("studies:save", (event, study) => db.saveStudy(study));
+ipcMain.handle("reports:save", (event, report) => db.saveBrainReport(report));
+
+ipcMain.handle("patients:list", () => db.listPatients());
+ipcMain.handle("studies:byPatient", (event, patientId) => db.listStudies(patientId));

--- a/mri-report-app/package.json
+++ b/mri-report-app/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mri-report-app",
+  "version": "1.0.0",
+  "description": "Electron-based RSNA brain MRI reporting tool with SQLite persistence.",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "lint": "echo 'No lint configured'"
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.0.0"
+  },
+  "devDependencies": {
+    "electron": "^33.0.0"
+  }
+}

--- a/mri-report-app/renderer/index.html
+++ b/mri-report-app/renderer/index.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="tk">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Beýni MRT - RSNA gurluşly hasabat</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="app-header">
+    <h1>RSNA görnüşli beýni MRT studiýasy</h1>
+    <p class="muted">Electron + SQLite görnüşindäki stasionar demo</p>
+  </header>
+
+  <main>
+    <section class="card">
+      <div class="section-heading">
+        <div>
+          <p class="eyebrow">1. Näsag maglumatlary</p>
+          <h2>Pacienti ýaz</h2>
+        </div>
+        <button id="load-patients" type="button">Ýatda saklanlary görkez</button>
+      </div>
+      <div class="grid">
+        <label>Familiýasy, ady<input id="p-fullname" type="text" required /></label>
+        <label>Doglan senesi<input id="p-birth" type="date" /></label>
+        <label>Jynsy
+          <select id="p-gender">
+            <option value="erkek">Erkek</option>
+            <option value="aýal">Aýal</option>
+          </select>
+        </label>
+        <label>Kart / ID<input id="p-id" type="text" /></label>
+      </div>
+      <div class="actions">
+        <button id="btn-save-patient" type="button" class="primary">Pacienti ýaz</button>
+        <p id="patient-status" class="muted"></p>
+      </div>
+      <div id="patient-list" class="list"></div>
+    </section>
+
+    <section class="card">
+      <p class="eyebrow">2. Barlag maglumatlary</p>
+      <h2>Barlag sessiýasy</h2>
+      <div class="grid">
+        <label>Barlag senesi<input id="s-date" type="date" /></label>
+        <label>Ugratýan lukman<input id="s-ref" type="text" /></label>
+        <label class="full">Kliniki maglumat<textarea id="s-clinical" rows="2"></textarea></label>
+        <label><input id="s-is-followup" type="checkbox" /> Gaýtadan barlag</label>
+        <label>Öňki barlag senesi<input id="s-prev-date" type="date" /></label>
+      </div>
+    </section>
+
+    <section class="card">
+      <p class="eyebrow">3. Tapyndylar</p>
+      <h2>Beýni MRT meýdançalary</h2>
+      <div class="grid">
+        <label>Artefaktlar
+          <select id="r-artefacts">
+            <option value="ýok">Artefaktlar ýok</option>
+            <option value="hereket">Hereket artefakty</option>
+            <option value="metal_klips">Metal klips</option>
+          </select>
+        </label>
+        <label>Çelek şekili
+          <select id="r-skull-shape">
+            <option value="">Saýla</option>
+            <option value="mezo">Mezosefalik</option>
+            <option value="dolihosefalik">Dolihosefalik</option>
+            <option value="brahiosefalik">Brahiosefalik</option>
+          </select>
+        </label>
+        <label class="full">Ishemiýa / diskirkulýator<textarea id="r-lesions-ischemic" rows="2"></textarea></label>
+        <label class="full">Gemorragik ojaklar<textarea id="r-lesions-hemorrhagic" rows="2"></textarea></label>
+        <label class="full">Demielinizasion ojaklar<textarea id="r-lesions-demyelinating" rows="2"></textarea></label>
+        <label class="full">Kistalar<textarea id="r-cysts" rows="2"></textarea></label>
+        <label class="full">Tumor / mass<textarea id="r-mass" rows="2"></textarea></label>
+        <label class="full">Injekler<textarea id="r-ventricles" rows="2"></textarea></label>
+        <label class="full">Bazal sisternalar<textarea id="r-cisterns" rows="2"></textarea></label>
+        <label class="full">Subarahnoidal giňişlik<textarea id="r-subarachnoid" rows="2"></textarea></label>
+        <label class="full">Gipofiz<textarea id="r-pituitary" rows="2"></textarea></label>
+        <label class="full">Orbit<textarea id="r-orbit" rows="2"></textarea></label>
+        <label class="full">Wagt süňki<textarea id="r-temporal" rows="2"></textarea></label>
+        <label class="full">Kranial nerwler<textarea id="r-nerves" rows="2"></textarea></label>
+        <label class="full">Angiografiýa<textarea id="r-angio" rows="2"></textarea></label>
+        <label class="full">Netije<textarea id="r-conclusion" rows="3"></textarea></label>
+        <label class="full">Maslahat<textarea id="r-recommendations" rows="3"></textarea></label>
+      </div>
+      <div class="actions">
+        <button id="btn-generate" type="button" class="primary">Hasabat döret we sakla</button>
+      </div>
+    </section>
+
+    <section class="card">
+      <p class="eyebrow">4. Netije</p>
+      <h2>Taýýar tekst</h2>
+      <textarea id="output-text" rows="14" class="fullwidth"></textarea>
+    </section>
+  </main>
+
+  <script src="renderer.js"></script>
+</body>
+</html>

--- a/mri-report-app/renderer/preload.js
+++ b/mri-report-app/renderer/preload.js
@@ -1,0 +1,9 @@
+const { contextBridge, ipcRenderer } = require("electron");
+
+contextBridge.exposeInMainWorld("api", {
+  savePatient: (data) => ipcRenderer.invoke("patients:save", data),
+  saveStudy: (data) => ipcRenderer.invoke("studies:save", data),
+  saveReport: (data) => ipcRenderer.invoke("reports:save", data),
+  listPatients: () => ipcRenderer.invoke("patients:list"),
+  listStudies: (patientId) => ipcRenderer.invoke("studies:byPatient", patientId),
+});

--- a/mri-report-app/renderer/renderer.js
+++ b/mri-report-app/renderer/renderer.js
@@ -1,0 +1,213 @@
+let currentPatientId = null;
+let currentStudyId = null;
+
+window.addEventListener("DOMContentLoaded", () => {
+  wirePatientSection();
+  wireReportSection();
+  refreshPatients();
+});
+
+function wirePatientSection() {
+  const saveBtn = document.getElementById("btn-save-patient");
+  const loadBtn = document.getElementById("load-patients");
+
+  saveBtn?.addEventListener("click", async () => {
+    const patient = {
+      full_name: document.getElementById("p-fullname")?.value || "",
+      birth_date: document.getElementById("p-birth")?.value || "",
+      gender: document.getElementById("p-gender")?.value || "",
+      hospital_id: document.getElementById("p-id")?.value || "",
+    };
+    if (!patient.full_name) {
+      setStatus("patient-status", "Ady ýazmaly.");
+      return;
+    }
+
+    currentPatientId = await window.api.savePatient(patient);
+    setStatus("patient-status", `Saklandy (ID: ${currentPatientId})`);
+    refreshPatients();
+  });
+
+  loadBtn?.addEventListener("click", refreshPatients);
+}
+
+function wireReportSection() {
+  const generateBtn = document.getElementById("btn-generate");
+  generateBtn?.addEventListener("click", async () => {
+    if (!currentPatientId) {
+      alert("Ilki bilen pacient ýazylmaly.");
+      return;
+    }
+
+    const study = {
+      patient_id: currentPatientId,
+      study_date: document.getElementById("s-date")?.value || new Date().toISOString().slice(0, 10),
+      modality: "MRI",
+      region: "Beýni",
+      ref_physician: document.getElementById("s-ref")?.value || "",
+      clinical_info: document.getElementById("s-clinical")?.value || "",
+      is_followup: document.getElementById("s-is-followup")?.checked ? 1 : 0,
+      prev_study_date: document.getElementById("s-prev-date")?.value || null,
+    };
+    currentStudyId = await window.api.saveStudy(study);
+
+    const report = buildReportPayload();
+    const reportId = await window.api.saveReport({ ...report, study_id: currentStudyId });
+
+    const text = generateReportText(study, report);
+    const output = document.getElementById("output-text");
+    if (output) {
+      output.value = text;
+    }
+
+    alert(`Hasabat saklandy (ID: ${reportId})`);
+  });
+}
+
+function buildReportPayload() {
+  return {
+    artefacts_type: document.getElementById("r-artefacts")?.value || "",
+    skull_shape: document.getElementById("r-skull-shape")?.value || "",
+    skull_sutures: "",
+    skull_form_symmetry: "",
+    posterior_fossa: "",
+    lesions_ischemic: document.getElementById("r-lesions-ischemic")?.value || "",
+    lesions_hemorrhagic: document.getElementById("r-lesions-hemorrhagic")?.value || "",
+    lesions_demyelinating: document.getElementById("r-lesions-demyelinating")?.value || "",
+    lesions_number: "",
+    lesions_location: "",
+    lesions_size: "",
+    cysts_info: document.getElementById("r-cysts")?.value || "",
+    mass_info: document.getElementById("r-mass")?.value || "",
+    ventricles_info: document.getElementById("r-ventricles")?.value || "",
+    cisterns_info: document.getElementById("r-cisterns")?.value || "",
+    subarachnoid_info: document.getElementById("r-subarachnoid")?.value || "",
+    pituitary_info: document.getElementById("r-pituitary")?.value || "",
+    orbit_info: document.getElementById("r-orbit")?.value || "",
+    temporal_bone_info: document.getElementById("r-temporal")?.value || "",
+    cranial_nerves_info: document.getElementById("r-nerves")?.value || "",
+    angio_info: document.getElementById("r-angio")?.value || "",
+    conclusion: document.getElementById("r-conclusion")?.value || "",
+    recommendations: document.getElementById("r-recommendations")?.value || "",
+  };
+}
+
+function generateReportText(study, r) {
+  let txt = "";
+  txt += "BEÝNI MRT – RSNA gurluşly hasabat\n\n";
+  txt += "1) Umumy maglumatlar\n";
+  txt += `Barlyk görnüşi: ${study.modality}, sebit: ${study.region}\n`;
+  txt += `Barlag senesi: ${study.study_date}\n`;
+  if (study.is_followup) {
+    txt += `Gaýtadan barlag, öňki barlag senesi: ${study.prev_study_date || ""}\n`;
+  }
+  txt += `Kliniki maglumat: ${study.clinical_info}\n\n`;
+
+  txt += "2) Barlag protokoly\n";
+  txt += `Artefaktlar: ${humanArtefact(r.artefacts_type)}.\n\n`;
+
+  txt += "3) Beýni parenhima we ojaklar\n";
+  if (r.lesions_ischemic) txt += `Diskirkulýator üýtgemeler: ${r.lesions_ischemic}\n`;
+  if (r.lesions_hemorrhagic) txt += `Gemorragik ojaklar: ${r.lesions_hemorrhagic}\n`;
+  if (r.lesions_demyelinating) txt += `Demielinizasion üýtgemeler: ${r.lesions_demyelinating}\n`;
+  txt += "\n";
+
+  if (r.cysts_info) {
+    txt += "4) Kistalar:\n";
+    txt += `${r.cysts_info}\n\n`;
+  }
+
+  if (r.mass_info) {
+    txt += "5) Dörän döremeler:\n";
+    txt += `${r.mass_info}\n\n`;
+  }
+
+  txt += "6) Likwor giňişlikleri\n";
+  if (r.ventricles_info) txt += `Injekler: ${r.ventricles_info}\n`;
+  if (r.cisterns_info) txt += `Bazal sisternalar: ${r.cisterns_info}\n`;
+  if (r.subarachnoid_info) txt += `Subarahnoidal giňişlikler: ${r.subarachnoid_info}\n`;
+  txt += "\n";
+
+  if (r.pituitary_info || r.orbit_info || r.temporal_bone_info || r.cranial_nerves_info) {
+    txt += "7) Gipofiz, orbit, wagt süňki, kranial nerwler:\n";
+    if (r.pituitary_info) txt += `Gipofiz: ${r.pituitary_info}\n`;
+    if (r.orbit_info) txt += `Orbit: ${r.orbit_info}\n`;
+    if (r.temporal_bone_info) txt += `Wagt süňki: ${r.temporal_bone_info}\n`;
+    if (r.cranial_nerves_info) txt += `Kranial nerwler: ${r.cranial_nerves_info}\n`;
+    txt += "\n";
+  }
+
+  if (r.angio_info) {
+    txt += "8) MR-angiografiýa:\n";
+    txt += `${r.angio_info}\n\n`;
+  }
+
+  txt += "9) Netije:\n";
+  txt += `${r.conclusion}\n\n`;
+
+  if (r.recommendations) {
+    txt += "Maslahatlar:\n";
+    txt += `${r.recommendations}\n`;
+  }
+
+  return txt;
+}
+
+function humanArtefact(code) {
+  switch (code) {
+    case "ýok":
+      return "Artefaktlar tapylmady";
+    case "hereket":
+      return "Hereketden dörän artefaktlar";
+    case "metal_klips":
+      return "Metal klips projektsiýasyndaky artefakt";
+    default:
+      return "";
+  }
+}
+
+async function refreshPatients() {
+  const list = document.getElementById("patient-list");
+  if (!list) return;
+  const patients = await window.api.listPatients();
+  if (!patients || patients.length === 0) {
+    list.innerHTML = "<p class=\"muted\">Ýatda saklanan pacient ýok.</p>";
+    return;
+  }
+
+  list.innerHTML = patients
+    .map(
+      (p) => `
+        <button class="list-item" data-id="${p.id}">
+          <strong>${p.full_name}</strong><br />
+          <span class="muted">${p.birth_date || "?"} · ${p.gender || ""}</span>
+        </button>
+      `
+    )
+    .join("");
+
+  list.querySelectorAll(".list-item").forEach((btn) => {
+    btn.addEventListener("click", async () => {
+      currentPatientId = Number(btn.dataset.id);
+      setStatus("patient-status", `Saýlanan pacient ID: ${currentPatientId}`);
+      await refreshStudies(currentPatientId);
+    });
+  });
+}
+
+async function refreshStudies(patientId) {
+  const studies = await window.api.listStudies(patientId);
+  if (studies.length > 0) {
+    setStatus(
+      "patient-status",
+      `Saýlanan pacientde ${studies.length} barlag bar. Iň soňkysy: ${studies[0].study_date}.`
+    );
+  }
+}
+
+function setStatus(elementId, message) {
+  const el = document.getElementById(elementId);
+  if (el) {
+    el.textContent = message;
+  }
+}

--- a/mri-report-app/renderer/styles.css
+++ b/mri-report-app/renderer/styles.css
@@ -1,0 +1,154 @@
+:root {
+  --bg: #0b1021;
+  --card: #121a31;
+  --text: #e8ecf7;
+  --muted: #9fb2d2;
+  --accent: #3da9fc;
+  --border: #1f2944;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at 20% 20%, #111b33, #0a0f1f 55%);
+  color: var(--text);
+  line-height: 1.5;
+  padding: 24px;
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 16px;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 16px 20px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+}
+
+.section-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+  margin-top: 12px;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+input,
+select,
+textarea,
+button {
+  font: inherit;
+}
+
+input,
+select,
+textarea {
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: #0e1628;
+  color: var(--text);
+}
+
+textarea.fullwidth {
+  width: 100%;
+}
+
+textarea {
+  resize: vertical;
+}
+
+button {
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: #172343;
+  color: var(--text);
+  cursor: pointer;
+}
+
+button.primary {
+  background: linear-gradient(120deg, #3da9fc, #8ba9ff);
+  border: none;
+  color: #0a0f1f;
+  font-weight: 600;
+}
+
+button:hover {
+  opacity: 0.95;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  font-size: 12px;
+  margin: 0;
+}
+
+h1,
+h2,
+h3 {
+  margin: 6px 0;
+}
+
+.muted {
+  color: var(--muted);
+  margin: 0;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.full {
+  grid-column: 1 / -1;
+}
+
+.list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.list-item {
+  border: 1px solid var(--border);
+  background: #0f1a31;
+  border-radius: 12px;
+  padding: 10px 12px;
+  text-align: left;
+}

--- a/mri-report-app/sql/init.sql
+++ b/mri-report-app/sql/init.sql
@@ -1,0 +1,50 @@
+CREATE TABLE IF NOT EXISTS patients (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    full_name TEXT NOT NULL,
+    birth_date TEXT,
+    gender TEXT,
+    hospital_id TEXT
+);
+
+CREATE TABLE IF NOT EXISTS studies (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    patient_id INTEGER NOT NULL,
+    study_date TEXT NOT NULL,
+    modality TEXT DEFAULT 'MRI',
+    region TEXT DEFAULT 'Beýni',
+    ref_physician TEXT,
+    clinical_info TEXT,
+    is_followup INTEGER DEFAULT 0,
+    prev_study_date TEXT,
+    FOREIGN KEY(patient_id) REFERENCES patients(id)
+);
+
+CREATE TABLE IF NOT EXISTS brain_mri_reports (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    study_id INTEGER NOT NULL,
+    artefacts_type TEXT,
+    skull_shape TEXT,
+    skull_sutures TEXT,
+    skull_form_symmetry TEXT,
+    posterior_fossa TEXT,
+    lesions_ischemic TEXT,
+    lesions_hemorrhagic TEXT,
+    lesions_demyelinating TEXT,
+    lesions_number TEXT,
+    lesions_location TEXT,
+    lesions_size TEXT,
+    cysts_info TEXT,
+    mass_info TEXT,
+    ventricles_info TEXT,
+    cisterns_info TEXT,
+    subarachnoid_info TEXT,
+    pituitary_info TEXT,
+    orbit_info TEXT,
+    temporal_bone_info TEXT,
+    cranial_nerves_info TEXT,
+    angio_info TEXT,
+    conclusion TEXT,
+    recommendations TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(study_id) REFERENCES studies(id)
+);


### PR DESCRIPTION
## Summary
- add Electron desktop scaffold with SQLite-backed persistence for patients, studies, and brain MRI reports
- provide renderer UI for capturing patient/study data and generating RSNA-style text output
- include schema initialization SQL and basic styling for the desktop form

## Testing
- not run (development environment only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b955e29dc8329b23ab295dcd02149)