### PR TITLE
Render pathology checkboxes as a list

### DIFF
--- a/app.js
+++ b/app.js
@@ -171,23 +171,25 @@ function renderSnippetCards() {
                 <h3>${section.title}</h3>
               </div>
             </div>
-            <div class="survey-options" aria-label="${section.title}">
+            <ul class="survey-options" aria-label="${section.title}">
               ${section.options
                 .map(
                   (option, optionIndex) => `
-                    <label class="option compact">
-                      <input
-                        type="checkbox"
-                        data-category="${section.id}"
-                        data-value="${option}"
-                        id="${section.id}-${optionIndex}"
-                      />
-                      <span>${option}</span>
-                    </label>
+                    <li class="survey-option">
+                      <label class="option compact">
+                        <input
+                          type="checkbox"
+                          data-category="${section.id}"
+                          data-value="${option}"
+                          id="${section.id}-${optionIndex}"
+                        />
+                        <span>${option}</span>
+                      </label>
+                    </li>
                   `,
                 )
                 .join("")}
-            </div>
+            </ul>
           </article>
         `,
       ).join("")}

--- a/styles.css
+++ b/styles.css
@@ -211,10 +211,17 @@ main {
 }
 
 .survey-options {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: 8px;
-  align-items: start;
+  padding-left: 18px;
+  list-style: disc;
+  list-style-position: outside;
+  margin: 0;
+}
+
+.survey-option {
+  list-style: disc;
 }
 
 .content-grid {


### PR DESCRIPTION
## Summary
- render pathology option groups as unordered lists instead of grid containers
- stack checkbox options vertically with list styling for clearer list presentation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ba8e343f48329afdcee392b763813)