### PR TITLE
Improve accessibility semantics and focus cues

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,7 +28,7 @@ function renderShell() {
   if (!app) return;
 
   app.innerHTML = `
-    <section class="hero">
+    <section class="hero" id="introSection">
       <div class="hero-text">
         <p class="eyebrow">Awtomatlaşdyrylan forma</p>
         <h1>Beýni MRT hasabatlaryny kliniki logika bilen ýygna</h1>
@@ -53,16 +53,16 @@ function renderShell() {
       </div>
     </section>
 
-    <section class="card form-card">
+    <section class="card form-card" id="formSection">
       <div class="section-header">
         <div>
           <p class="eyebrow">Umumy maglumatlar</p>
-          <h2>Näsag we barlag barada</h2>
-          <p class="muted">Hasabatyň başyndaky hökmany maglumatlar.</p>
+          <h2 id="formHeading">Näsag we barlag barada</h2>
+          <p class="muted" id="formDescription">Hasabatyň başyndaky hökmany maglumatlar.</p>
         </div>
         <div class="pill">Hasabat awtodolyşygi</div>
       </div>
-      <div class="form-grid">
+      <form class="form-grid" aria-labelledby="formHeading formDescription" id="reportForm" novalidate>
         <label class="form-field">
           <span>Familiýasy, ady</span>
           <input data-field="patientName" type="text" placeholder="Amanow Aman" />
@@ -87,50 +87,71 @@ function renderShell() {
           <input data-field="epilepsyCuts" type="checkbox" />
           <span>Epilepsiýa ýagdaýynda ýörite kosý kesimler ýerine ýetirildi</span>
         </label>
-      </div>
+      </form>
     </section>
 
-    <section class="content">
+    <section class="content" id="snippetSection">
       <div class="section-header">
         <div>
           <p class="eyebrow">Patologiýa wariantlary</p>
-          <h2>Beýanlamalary bellik görnüşinde saýlaň</h2>
-          <p class="muted">Her karta kliniki taýdan degişli standart sözlem toplumy bolup, saýlananlary awtomatiki netije girizýär.</p>
+          <h2 id="snippetHeading">Beýanlamalary bellik görnüşinde saýlaň</h2>
+          <p class="muted" id="snippetDescription">Her karta kliniki taýdan degişli standart sözlem toplumy bolup, saýlananlary awtomatiki netije girizýär.</p>
         </div>
         <div class="pill">RSNA.txt esasynda</div>
       </div>
-      <div class="content-grid" id="snippetGrid" aria-busy="true">${renderSnippetSkeleton()}</div>
+      <div
+        class="content-grid"
+        id="snippetGrid"
+        aria-busy="true"
+        aria-labelledby="snippetHeading snippetDescription"
+        role="group"
+      >${renderSnippetSkeleton()}</div>
     </section>
 
-    <section class="card note-card">
+    <section class="card note-card" id="notesSection">
       <div class="section-header">
         <div>
           <p class="eyebrow">Goşmaça bellik</p>
-          <h2>Erkin ýazgy</h2>
-          <p class="muted">Awtomatlaşdyrma üpjün etmeýän jikme-jiklikleri goşuň.</p>
+          <h2 id="notesHeading">Erkin ýazgy</h2>
+          <p class="muted" id="notesDescription">Awtomatlaşdyrma üpjün etmeýän jikme-jiklikleri goşuň.</p>
         </div>
         <div class="pill">Islege görä</div>
       </div>
-      <textarea data-field="customNotes" rows="3" placeholder="Meselem: kontrast toplama ýok, dinamika boýunça üýtgeşme bar ..."></textarea>
+      <label class="form-field" for="customNotes">
+        <span class="visually-hidden" id="notesLabel">Goşmaça bellik meýdany</span>
+        <textarea
+          id="customNotes"
+          data-field="customNotes"
+          rows="3"
+          aria-labelledby="notesHeading notesDescription notesLabel"
+          placeholder="Meselem: kontrast toplama ýok, dinamika boýunça üýtgeşme bar ..."
+        ></textarea>
+      </label>
     </section>
 
-    <section class="card preview-card">
+    <section class="card preview-card" id="previewSection">
       <div class="section-header">
         <div>
           <p class="eyebrow">Netije</p>
-          <h2>Awtodöredilen tekst</h2>
-          <p class="muted">Saýlanan wariantlar esasynda düzülen görnüşli tekst.</p>
+          <h2 id="previewHeading">Awtodöredilen tekst</h2>
+          <p class="muted" id="previewDescription">Saýlanan wariantlar esasynda düzülen görnüşli tekst.</p>
         </div>
         <div class="actions">
-          <button id="copyReport" class="btn ghost">Köçürmek</button>
-          <button id="exportDoc" class="btn">Word görnüşinde eksport</button>
+          <button id="copyReport" class="btn ghost" aria-label="Netije blokyny göçürmek">Köçürmek</button>
+          <button id="exportDoc" class="btn" aria-label="Netijäni Word görnüşinde eksport etmek">Word görnüşinde eksport</button>
         </div>
       </div>
       <div class="chip-row" id="selectionChips"></div>
-      <textarea id="reportText" rows="12" readonly></textarea>
+      <textarea
+        id="reportText"
+        rows="12"
+        readonly
+        aria-labelledby="previewHeading previewDescription"
+        aria-live="polite"
+      ></textarea>
     </section>
 
-    <section class="card db-card">
+    <section class="card db-card" id="storageSection">
       <div class="section-header">
         <div>
           <p class="eyebrow">Protokol ammary</p>
@@ -140,10 +161,10 @@ function renderShell() {
         <div class="pill" id="dbStatus">Ýüklenýär...</div>
       </div>
       <div class="db-grid">
-        <div class="form-field">
+        <label class="form-field" for="protocolTitle">
           <span>Protokolyň ady</span>
           <input id="protocolTitle" type="text" placeholder="Mysal: Diskirkulýar 65 ýaş" />
-        </div>
+        </label>
         <div class="db-actions">
           <button id="saveProtocol" class="btn">Ýatda saklamak</button>
           <button id="refreshProtocolList" class="btn ghost">Sanawy täzeden al</button>
@@ -184,15 +205,20 @@ function renderSnippetCards(snippets) {
       ${snippets
         .map(
           (section, idx) => `
-            <article class="survey-item selection-card" data-section="${section.id}" role="listitem">
+            <article
+              class="survey-item selection-card"
+              data-section="${section.id}"
+              role="listitem"
+              aria-labelledby="${section.id}-title"
+            >
               <div class="survey-heading">
                 <div class="survey-index">${idx + 1}</div>
                 <div>
                   <p class="eyebrow">Patologiýa bölümi</p>
-                  <h3>${section.title}</h3>
+                  <h3 id="${section.id}-title">${section.title}</h3>
                 </div>
               </div>
-              <ul class="survey-options" aria-label="${section.title}">
+              <ul class="survey-options" aria-labelledby="${section.id}-title">
                 ${section.options
                   .map(
                     (option, optionIndex) => `
@@ -240,6 +266,11 @@ function loadSnippets() {
 }
 
 function bindInteractions() {
+  const form = document.getElementById("reportForm");
+  if (form) {
+    form.addEventListener("submit", (event) => event.preventDefault());
+  }
+
   document.querySelectorAll("[data-field]").forEach((input) => {
     if (input.type === "checkbox") {
       input.addEventListener("change", () => {

--- a/index.html
+++ b/index.html
@@ -70,15 +70,24 @@
   </style>
 </head>
 <body>
+  <a class="skip-link" href="#mainContent">Mazmuna geç</a>
   <header role="banner">
     <div>
       <p class="app-title">RSNA / 022 şablony</p>
       <p class="app-subtitle">Beýni MRT hasabatlaryny awtomatlaşdyrmak üçin saýty</p>
     </div>
-    <div class="badge">SQL.js ýatda saklaýyş + Word eksporty</div>
+    <nav aria-label="Esasy bölümler">
+      <ul class="nav-links">
+        <li><a href="#formSection">Umumy maglumatlar</a></li>
+        <li><a href="#snippetSection">Patologiýa wariantlary</a></li>
+        <li><a href="#previewSection">Netije</a></li>
+        <li><a href="#storageSection">Ammar</a></li>
+      </ul>
+    </nav>
+    <div class="badge" aria-label="SQL.js ýatda saklaýyş + Word eksporty">SQL.js ýatda saklaýyş + Word eksporty</div>
   </header>
 
-  <main aria-live="polite">
+  <main id="mainContent" aria-live="polite">
     <div id="app" class="page"></div>
   </main>
 

--- a/styles.css
+++ b/styles.css
@@ -32,6 +32,18 @@
   box-sizing: border-box;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 body {
   margin: 0;
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -51,6 +63,24 @@ footer {
   padding: 24px 20px;
 }
 
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: 10px;
+  background: var(--accent);
+  color: white;
+  padding: 10px 12px;
+  border-radius: 10px;
+  z-index: 10;
+  text-decoration: none;
+}
+
+.skip-link:focus-visible {
+  left: 16px;
+  outline: 3px solid #fbbf24;
+  outline-offset: 3px;
+}
+
 header {
   display: flex;
   justify-content: space-between;
@@ -58,6 +88,31 @@ header {
   gap: 16px;
   flex-wrap: wrap;
   border-bottom: 1px solid var(--border);
+}
+
+.nav-links {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  flex-wrap: wrap;
+}
+
+.nav-links a {
+  color: var(--text);
+  font-weight: 700;
+  text-decoration: none;
+  padding: 8px 10px;
+  border-radius: 8px;
+}
+
+.nav-links a:focus-visible,
+.nav-links a:hover {
+  background: rgba(37, 99, 235, 0.1);
+  outline: 2px solid rgba(37, 99, 235, 0.3);
+  outline-offset: 2px;
 }
 
 .app-title {
@@ -308,9 +363,9 @@ main {
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.form-field input:focus,
-.form-field textarea:focus,
-.form-field select:focus {
+.form-field input:focus-visible,
+.form-field textarea:focus-visible,
+.form-field select:focus-visible {
   outline: none;
   border-color: var(--accent);
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
@@ -356,6 +411,12 @@ main {
   margin-top: 2px;
 }
 
+input[type="checkbox"]:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.35);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 .note-card textarea,
 .preview-card textarea {
   width: 100%;
@@ -370,6 +431,14 @@ main {
 
 .preview-card textarea {
   min-height: 240px;
+}
+
+.note-card textarea:focus-visible,
+.preview-card textarea:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.2);
+  outline-offset: 2px;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
 }
 
 .actions {
@@ -387,6 +456,12 @@ main {
   font-weight: 700;
   cursor: pointer;
   transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.btn:focus-visible {
+  outline: 3px solid #fbbf24;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
 }
 
 .btn:hover {


### PR DESCRIPTION
## Summary
- Add skip link navigation, in-page anchors, and aria labels to strengthen page semantics
- Wrap report inputs in a form, tie labels to fields, and label snippet option groups for assistive tech
- Provide visible focus outlines for buttons, checkboxes, and text areas to support keyboard navigation

## Testing
- npx @axe-core/cli http://localhost:8000 *(fails: npm registry access denied)*
- npx lighthouse http://localhost:8000 --quiet --chrome-flags="--headless" --output=json --output-path=./lighthouse.json *(fails: npm registry access denied)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bac1e2094832998ab7668311f99ea)