### PR TITLE
Add CTA-focused funnel analytics and form UX improvements

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -1,0 +1,141 @@
+const STORAGE_KEY = "mri_analytics_v1";
+const DEFAULT_FUNNEL = {
+  hero_cta: 0,
+  form_start: 0,
+  snippet_select: 0,
+  report_ready: 0,
+  protocol_saved: 0,
+};
+const VARIANTS = {
+  A: { heading: "Beýni MRT hasabatlaryny kliniki logika bilen ýygna", cta: "Formany aç we başla" },
+  B: { heading: "RSNA/022 boýunça hasabaty 60 sekuntda taýýarla", cta: "Hasabat döretmäge geç" },
+};
+export const CTA_VARIANTS = VARIANTS;
+
+let analytics = {
+  funnel: { ...DEFAULT_FUNNEL },
+  variant: "A",
+  variantStats: {
+    A: { views: 0, clicks: 0 },
+    B: { views: 0, clicks: 0 },
+  },
+  events: [],
+};
+
+function loadAnalytics() {
+  if (typeof localStorage === "undefined") return;
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored);
+      analytics = {
+        ...analytics,
+        ...parsed,
+        funnel: { ...DEFAULT_FUNNEL, ...parsed.funnel },
+        variantStats: {
+          A: { views: 0, clicks: 0, ...(parsed.variantStats?.A || {}) },
+          B: { views: 0, clicks: 0, ...(parsed.variantStats?.B || {}) },
+        },
+      };
+    } catch (e) {
+      console.warn("Analytics decode failed", e);
+    }
+  }
+}
+
+function persist() {
+  if (typeof localStorage === "undefined") return;
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({
+      funnel: analytics.funnel,
+      variant: analytics.variant,
+      variantStats: analytics.variantStats,
+      events: analytics.events,
+    }),
+  );
+}
+
+export function initAnalytics() {
+  loadAnalytics();
+  analytics.variant = selectVariant();
+  incrementVariantViews(analytics.variant);
+  trackEvent("page_view", { variant: analytics.variant });
+  persist();
+  return getVariantCopy();
+}
+
+export function getVariantKey() {
+  return analytics.variant;
+}
+
+function selectVariant() {
+  if (analytics.variant === "A" || analytics.variant === "B") return analytics.variant;
+  const stored = typeof localStorage !== "undefined" ? localStorage.getItem("mri_cta_variant") : null;
+  if (stored === "A" || stored === "B") return stored;
+  const chosen = Math.random() > 0.5 ? "A" : "B";
+  if (typeof localStorage !== "undefined") {
+    localStorage.setItem("mri_cta_variant", chosen);
+  }
+  return chosen;
+}
+
+function incrementVariantViews(variant) {
+  analytics.variantStats[variant].views += 1;
+}
+
+export function recordCtaClick() {
+  analytics.variantStats[analytics.variant].clicks += 1;
+  trackEvent("cta_click", { variant: analytics.variant });
+  persist();
+}
+
+export function getVariantCopy() {
+  return VARIANTS[analytics.variant];
+}
+
+export function recordFunnelStep(step, payload = {}) {
+  if (!Object.hasOwn(DEFAULT_FUNNEL, step)) return;
+  analytics.funnel[step] = (analytics.funnel[step] || 0) + 1;
+  trackEvent(`funnel_${step}`); 
+  if (payload.variant) {
+    trackEvent(`variant_${payload.variant}_${step}`);
+  }
+  persist();
+}
+
+export function trackEvent(name, payload = {}) {
+  analytics.events.unshift({
+    name,
+    payload,
+    at: new Date().toISOString(),
+  });
+  analytics.events = analytics.events.slice(0, 25);
+  persist();
+}
+
+export function getFunnelReport() {
+  const steps = Object.entries(DEFAULT_FUNNEL).map(([key]) => ({
+    id: key,
+    count: analytics.funnel[key] || 0,
+  }));
+
+  const drops = steps.map((step, index) => {
+    if (index === 0) return { drop: 0, from: null, to: step.id };
+    const prev = steps[index - 1];
+    return { drop: Math.max(0, (prev.count || 0) - (step.count || 0)), from: prev.id, to: step.id };
+  });
+
+  const biggestDrop = drops.reduce((max, current) => (current.drop > (max?.drop || 0) ? current : max), {
+    drop: 0,
+    from: null,
+    to: null,
+  });
+
+  return {
+    steps,
+    biggestDrop,
+    variantStats: analytics.variantStats,
+    variant: analytics.variant,
+  };
+}

--- a/styles.css
+++ b/styles.css
@@ -175,6 +175,22 @@ main {
   box-shadow: var(--shadow);
 }
 
+.hero-cta {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin: 14px 0 4px;
+}
+
+.primary-cta {
+  background: linear-gradient(135deg, #f97316, #ea580c);
+  box-shadow: 0 12px 30px rgba(234, 88, 12, 0.35);
+}
+
+.cta-note {
+  margin: 2px 0 0;
+}
+
 .hero h1 {
   margin: 6px 0 10px;
   font-size: 2rem;
@@ -351,6 +367,40 @@ main {
   color: var(--text);
 }
 
+.form-field.required > span::after {
+  content: " *";
+  color: var(--danger);
+  font-weight: 800;
+}
+
+.form-field[data-state="error"] input,
+.form-field[data-state="error"] textarea,
+.form-field[data-state="error"] select {
+  border-color: rgba(220, 38, 38, 0.4);
+  box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.1);
+}
+
+.form-field[data-state="success"] input,
+.form-field[data-state="success"] textarea,
+.form-field[data-state="success"] select {
+  border-color: rgba(22, 163, 74, 0.5);
+}
+
+.field-hint {
+  font-weight: 500;
+  font-size: 0.9rem;
+  color: var(--muted);
+  transition: color 0.2s ease;
+}
+
+.field-hint[data-state="error"] {
+  color: var(--danger);
+}
+
+.field-hint[data-state="success"] {
+  color: var(--success);
+}
+
 .form-field input,
 .form-field textarea,
 .form-field select {
@@ -447,6 +497,20 @@ input[type="checkbox"]:focus-visible {
   flex-wrap: wrap;
 }
 
+.inline-status {
+  min-height: 24px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.inline-status[data-state="success"] {
+  color: var(--success);
+}
+
+.inline-status[data-state="error"] {
+  color: var(--danger);
+}
+
 .btn {
   background: var(--accent);
   color: white;
@@ -537,6 +601,85 @@ input[type="checkbox"]:focus-visible {
 .row-actions {
   display: flex;
   gap: 8px;
+}
+
+.analytics-card h3 {
+  margin-top: 0;
+}
+
+.analytics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+}
+
+.funnel-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.funnel-row {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  background: #f8fafc;
+}
+
+.funnel-label {
+  font-weight: 700;
+}
+
+.funnel-meter {
+  margin-top: 6px;
+  height: 10px;
+  background: #e2e8f0;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.funnel-meter span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent), var(--accent-strong));
+}
+
+.variant-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 10px;
+}
+
+.variant-card {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  background: #fff7ed;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.04);
+}
+
+.variant-active {
+  border-color: rgba(234, 88, 12, 0.5);
+  box-shadow: 0 10px 24px rgba(234, 88, 12, 0.2);
+}
+
+.variant-name {
+  font-weight: 800;
+}
+
+.variant-copy {
+  margin: 4px 0 10px;
+  color: var(--muted);
+}
+
+.variant-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-weight: 700;
 }
 
 footer {


### PR DESCRIPTION
## Summary
- add analytics module with funnel drop-off detection and CTA variant tracking rendered in a new analytics card
- move a high-contrast hero CTA to the first screen and simplify form inputs with required cues, hints, and client-side validation
- add inline status feedback for copy/export/save actions and highlight drop-off results alongside A/B metrics

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bae2e91b083299ad110d1c697b0e7)