### PR TITLE
Improve mobile layout and loading performance

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,11 +35,11 @@ const fieldHelpers = {
   examContext: "Ilkinji/gaýtadan barlag, deňeşdirmeler ýaly jikme-jiklikleri ýazyň.",
 };
 
-document.addEventListener("DOMContentLoaded", async () => {
+document.addEventListener("DOMContentLoaded", () => {
   variantCopy = initAnalytics();
   renderShell();
   bindInteractions();
-  await renderSnippetSection();
+  scheduleSnippetLoad();
   applyStateToInputs();
   updateReportPreview();
   renderAnalyticsPanel();
@@ -248,6 +248,30 @@ async function renderSnippetSection() {
   grid.innerHTML = renderSnippetCards(snippets);
   grid.removeAttribute("aria-busy");
   bindSnippetInteractions();
+  applyStateToInputs();
+}
+
+function scheduleSnippetLoad() {
+  const grid = document.getElementById("snippetGrid");
+  if (!grid) return;
+
+  const load = () => renderSnippetSection();
+  if ("IntersectionObserver" in window) {
+    const observer = new IntersectionObserver(
+      (entries, obs) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          load();
+          obs.disconnect();
+        }
+      },
+      { rootMargin: "160px" },
+    );
+    observer.observe(grid);
+  } else if ("requestIdleCallback" in window) {
+    requestIdleCallback(load, { timeout: 500 });
+  } else {
+    setTimeout(load, 200);
+  }
 }
 
 function renderSnippetCards(snippets) {

--- a/index.html
+++ b/index.html
@@ -2,8 +2,13 @@
 <html lang="tk">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <title>Beýni MRT hasabat studiýasy</title>
+  <script>
+    if (navigator.connection?.saveData) {
+      document.documentElement.dataset.saveMode = "true";
+    }
+  </script>
   <link rel="preconnect" href="https://rsms.me" crossorigin />
   <link
     rel="preload"
@@ -38,14 +43,16 @@
       color: var(--text);
       line-height: 1.7;
       min-height: 100vh;
+      overflow-x: hidden;
     }
 
     header,
     main,
     footer {
       max-width: 1180px;
+      width: min(1180px, 100%);
       margin: 0 auto;
-      padding: 24px 20px;
+      padding: clamp(16px, 3vw, 24px) clamp(14px, 4vw, 24px);
     }
 
     header {

--- a/styles.css
+++ b/styles.css
@@ -53,14 +53,20 @@ body {
   color: var(--text);
   line-height: 1.7;
   min-height: 100vh;
+  overflow-x: hidden;
+}
+
+html[data-save-mode="true"] body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 header,
 main,
 footer {
   max-width: 1180px;
+  width: min(1180px, 100%);
   margin: 0 auto;
-  padding: 24px 20px;
+  padding: clamp(16px, 3vw, 24px) clamp(14px, 4vw, 24px);
 }
 
 .skip-link {
@@ -104,8 +110,12 @@ header {
   color: var(--text);
   font-weight: 700;
   text-decoration: none;
-  padding: 8px 10px;
-  border-radius: 8px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  min-height: 44px;
+  min-width: 44px;
+  display: inline-flex;
+  align-items: center;
 }
 
 .nav-links a:focus-visible,
@@ -161,7 +171,7 @@ main {
 
 .hero {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 16px;
   align-items: start;
 }
@@ -411,6 +421,7 @@ main {
   font-size: 1rem;
   font-family: inherit;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  min-height: 44px;
 }
 
 .form-field input:focus-visible,
@@ -430,6 +441,7 @@ main {
   align-items: center;
   gap: 10px;
   font-weight: 600;
+  min-height: 44px;
 }
 
 .option-list {
@@ -444,12 +456,13 @@ main {
   align-items: flex-start;
   border: 1px solid var(--border);
   border-radius: 10px;
-  padding: 10px 12px;
+  padding: 12px 14px;
   background: white;
+  min-height: 44px;
 }
 
 .option.compact {
-  padding: 8px 10px;
+  padding: 10px 12px;
   gap: 8px;
 }
 
@@ -516,10 +529,12 @@ input[type="checkbox"]:focus-visible {
   color: white;
   border: none;
   border-radius: 10px;
-  padding: 10px 14px;
+  padding: 12px 16px;
   font-weight: 700;
   cursor: pointer;
   transition: transform 0.1s ease, box-shadow 0.1s ease;
+  min-height: 44px;
+  min-width: 44px;
 }
 
 .btn:focus-visible {
@@ -587,10 +602,11 @@ input[type="checkbox"]:focus-visible {
   justify-content: space-between;
   align-items: center;
   gap: 12px;
-  padding: 12px;
+  padding: 14px;
   border: 1px solid var(--border);
   border-radius: 12px;
   background: #f8fafc;
+  min-height: 44px;
 }
 
 .protocol-title {
@@ -680,6 +696,17 @@ input[type="checkbox"]:focus-visible {
   flex-wrap: wrap;
   gap: 8px;
   font-weight: 700;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 footer {


### PR DESCRIPTION
## Summary
- add viewport adjustments and data-saver hint for lighter first paint
- increase touch target sizes and clamp layouts to remove horizontal scrolling
- lazily load snippet data and respect reduced-motion preferences for better mobile performance

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bb0ea0d2c83298dd4ec657ec66b82)