### PR TITLE
Add UI tokens, monitoring, and automated quality checks

### DIFF
--- a/mri-report-app/.eslintrc.cjs
+++ b/mri-report-app/.eslintrc.cjs
@@ -1,0 +1,16 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+    node: true,
+    jest: true,
+  },
+  extends: ["eslint:recommended", "prettier"],
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+  },
+  rules: {
+    "no-unused-vars": ["warn", { args: "none" }],
+  },
+};

--- a/mri-report-app/.github/workflows/ci.yml
+++ b/mri-report-app/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ["main", "master"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm install
+      - name: Lint JS
+        run: npm run lint
+      - name: Lint styles
+        run: npm run lint:css
+      - name: Run tests
+        run: npm test -- --runInBand
+      - name: Build Storybook
+        run: npm run build-storybook -- --quiet
+      - name: Visual regression test
+        run: npm run vrt

--- a/mri-report-app/.gitignore
+++ b/mri-report-app/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+storybook-static
+npm-debug.log*
+.DS_Store

--- a/mri-report-app/.prettierrc
+++ b/mri-report-app/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "printWidth": 100
+}

--- a/mri-report-app/.stylelintrc.cjs
+++ b/mri-report-app/.stylelintrc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  extends: ["stylelint-config-standard", "stylelint-config-prettier"],
+  rules: {},
+};

--- a/mri-report-app/__tests__/renderer.test.js
+++ b/mri-report-app/__tests__/renderer.test.js
@@ -1,0 +1,57 @@
+const { JSDOM } = require("jsdom");
+const { collectPathologyGroup, generateReportText, humanArtefact } = require("../renderer/renderer");
+
+describe("renderer utils", () => {
+  test("humanArtefact maps codes", () => {
+    expect(humanArtefact("ýok")).toBe("Artefaktlar tapylmady");
+    expect(humanArtefact("hereket")).toBe("Hereketden dörän artefaktlar");
+    expect(humanArtefact("metal_klips")).toBe("Metal klips projektsiýasyndaky artefakt");
+    expect(humanArtefact("other")).toBe("");
+  });
+
+  test("generateReportText renders follow-up content", () => {
+    const study = {
+      modality: "MRI",
+      region: "Beýni",
+      study_date: "2024-01-01",
+      is_followup: true,
+      prev_study_date: "2023-12-01",
+      clinical_info: "Neuro sx",
+    };
+    const report = {
+      artefacts_type: "ýok",
+      lesions_ischemic: "A",
+      lesions_hemorrhagic: "B",
+      lesions_demyelinating: "C",
+      ventricles_info: "V",
+      cisterns_info: "Cis",
+      subarachnoid_info: "Sub",
+      pituitary_info: "Pit",
+      orbit_info: "Orb",
+      temporal_bone_info: "Temp",
+      cranial_nerves_info: "Nerve",
+      angio_info: "Angio",
+      conclusion: "Done",
+      recommendations: "Rec",
+      cysts_info: "Cyst",
+      mass_info: "Mass",
+    };
+
+    const text = generateReportText(study, report);
+    expect(text).toContain("Gaýtadan barlag, öňki barlag senesi: 2023-12-01");
+    expect(text).toContain("Artefaktlar tapylmady");
+    expect(text).toContain("Angio");
+    expect(text).toContain("Maslahatlar");
+  });
+
+  test("collectPathologyGroup joins checkbox values and notes", () => {
+    const dom = new JSDOM(`
+      <input id="r-ischemic-note" value="extra" />
+      <input type="checkbox" data-pathology="ischemic" value="First" checked />
+      <input type="checkbox" data-pathology="ischemic" value="Second" />
+    `);
+    global.document = dom.window.document;
+
+    expect(collectPathologyGroup("ischemic")).toBe("First; extra");
+  });
+});

--- a/mri-report-app/jest.config.cjs
+++ b/mri-report-app/jest.config.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: "jsdom",
+  roots: ["<rootDir>/__tests__"],
+};

--- a/mri-report-app/package.json
+++ b/mri-report-app/package.json
@@ -5,12 +5,31 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "lint": "echo 'No lint configured'"
+    "lint": "eslint . --ext .js",
+    "lint:css": "stylelint \"renderer/**/*.css\"",
+    "format": "prettier --check \"**/*.{js,css,json,md}\"",
+    "test": "jest",
+    "storybook": "node scripts/storybook-server.js",
+    "build-storybook": "node scripts/build-storybook.js",
+    "vrt": "npm run build-storybook && node scripts/vrt.js",
+    "ci": "npm run lint && npm run lint:css && npm test && npm run vrt"
   },
   "dependencies": {
-    "better-sqlite3": "^11.0.0"
+    "better-sqlite3": "^11.0.0",
+    "web-vitals": "^4.2.2"
   },
   "devDependencies": {
-    "electron": "^33.0.0"
+    "electron": "^33.0.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "jest": "^29.7.0",
+    "jsdom": "^24.1.0",
+    "pixelmatch": "^5.3.0",
+    "pngjs": "^7.0.0",
+    "prettier": "^3.2.5",
+    "puppeteer": "^22.15.0",
+    "stylelint": "^15.11.0",
+    "stylelint-config-prettier": "^9.0.5",
+    "stylelint-config-standard": "^35.0.0"
   }
 }

--- a/mri-report-app/renderer/index.html
+++ b/mri-report-app/renderer/index.html
@@ -189,6 +189,7 @@
     </section>
   </main>
 
+  <script src="monitoring.js"></script>
   <script src="renderer.js"></script>
 </body>
 </html>

--- a/mri-report-app/renderer/monitoring.js
+++ b/mri-report-app/renderer/monitoring.js
@@ -1,0 +1,26 @@
+(function attachSentry() {
+  const dsn = window?.mriConfig?.sentryDsn;
+  if (!dsn) return;
+
+  const script = document.createElement("script");
+  script.src = "https://browser.sentry-cdn.com/7.118.0/bundle.min.js";
+  script.crossOrigin = "anonymous";
+  script.onload = () => {
+    if (!window.Sentry) return;
+    window.Sentry.init({
+      dsn,
+      integrations: [new window.Sentry.BrowserTracing()],
+      tracesSampleRate: 1.0,
+    });
+  };
+  document.head.appendChild(script);
+})();
+
+(function wireManualRumForwarding() {
+  if (!window.telemetry) return;
+  window.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") {
+      window.telemetry.captureRum({ name: "page_hidden", value: performance.now() });
+    }
+  });
+})();

--- a/mri-report-app/renderer/preload.js
+++ b/mri-report-app/renderer/preload.js
@@ -1,4 +1,10 @@
 const { contextBridge, ipcRenderer } = require("electron");
+const { onCLS, onINP, onLCP } = require("web-vitals");
+
+const sendRumMetric = (metric) => ipcRenderer.send("telemetry:rum", metric);
+onCLS(sendRumMetric);
+onINP(sendRumMetric);
+onLCP(sendRumMetric);
 
 contextBridge.exposeInMainWorld("api", {
   savePatient: (data) => ipcRenderer.invoke("patients:save", data),
@@ -6,4 +12,13 @@ contextBridge.exposeInMainWorld("api", {
   saveReport: (data) => ipcRenderer.invoke("reports:save", data),
   listPatients: () => ipcRenderer.invoke("patients:list"),
   listStudies: (patientId) => ipcRenderer.invoke("studies:byPatient", patientId),
+});
+
+contextBridge.exposeInMainWorld("telemetry", {
+  captureRum: sendRumMetric,
+});
+
+contextBridge.exposeInMainWorld("mriConfig", {
+  sentryDsn: process.env.SENTRY_DSN || "",
+  monitoringEndpoint: process.env.MONITORING_ENDPOINT || "",
 });

--- a/mri-report-app/renderer/renderer.js
+++ b/mri-report-app/renderer/renderer.js
@@ -235,3 +235,11 @@ function setStatus(elementId, message) {
     el.textContent = message;
   }
 }
+
+if (typeof module !== "undefined") {
+  module.exports = {
+    collectPathologyGroup,
+    generateReportText,
+    humanArtefact,
+  };
+}

--- a/mri-report-app/renderer/styles.css
+++ b/mri-report-app/renderer/styles.css
@@ -1,11 +1,4 @@
-:root {
-  --bg: #0b1021;
-  --card: #121a31;
-  --text: #e8ecf7;
-  --muted: #9fb2d2;
-  --accent: #3da9fc;
-  --border: #1f2944;
-}
+@import "./tokens.css";
 
 * {
   box-sizing: border-box;
@@ -13,54 +6,54 @@
 
 body {
   margin: 0;
-  font-family: "Inter", system-ui, -apple-system, sans-serif;
-  background: radial-gradient(circle at 20% 20%, #111b33, #0a0f1f 55%);
-  color: var(--text);
+  font-family: var(--font-base);
+  background: radial-gradient(circle at 20% 20%, #111b33, var(--color-bg) 55%);
+  color: var(--color-text);
   line-height: 1.5;
-  padding: 24px;
+  padding: var(--space-3xl);
 }
 
 .app-header {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  margin-bottom: 16px;
+  margin-bottom: var(--space-xl);
 }
 
 main {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--space-xl);
 }
 
 .card {
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: 16px;
-  padding: 16px 20px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-xl) var(--space-2xl);
+  box-shadow: var(--shadow-elevated);
 }
 
 .section-heading {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 12px;
+  gap: var(--space-lg);
 }
 
 .grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 12px;
-  margin-top: 12px;
+  gap: var(--space-lg);
+  margin-top: var(--space-lg);
 }
 
 label {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  font-size: 14px;
-  color: var(--muted);
+  gap: var(--space-xs);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
 }
 
 input,
@@ -73,11 +66,11 @@ button {
 input,
 select,
 textarea {
-  padding: 10px 12px;
-  border-radius: 10px;
-  border: 1px solid var(--border);
-  background: #0e1628;
-  color: var(--text);
+  padding: var(--space-md) var(--space-lg);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-input);
+  color: var(--color-text);
 }
 
 textarea.fullwidth {
@@ -89,18 +82,18 @@ textarea {
 }
 
 button {
-  padding: 10px 14px;
-  border-radius: 10px;
-  border: 1px solid var(--border);
+  padding: var(--space-md) var(--space-lg);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
   background: #172343;
-  color: var(--text);
+  color: var(--color-text);
   cursor: pointer;
 }
 
 button.primary {
-  background: linear-gradient(120deg, #3da9fc, #8ba9ff);
+  background: linear-gradient(120deg, var(--color-accent), var(--color-accent-strong));
   border: none;
-  color: #0a0f1f;
+  color: var(--color-bg);
   font-weight: 600;
 }
 
@@ -111,27 +104,27 @@ button:hover {
 .eyebrow {
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--muted);
-  font-size: 12px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
   margin: 0;
 }
 
 h1,
 h2,
 h3 {
-  margin: 6px 0;
+  margin: var(--space-xs) 0;
 }
 
 .muted {
-  color: var(--muted);
+  color: var(--color-text-muted);
   margin: 0;
 }
 
 .actions {
   display: flex;
   align-items: center;
-  gap: 12px;
-  margin-top: 12px;
+  gap: var(--space-lg);
+  margin-top: var(--space-lg);
 }
 
 .full {
@@ -140,56 +133,56 @@ h3 {
 
 .list {
   display: flex;
-  gap: 8px;
+  gap: var(--space-sm);
   flex-wrap: wrap;
-  margin-top: 10px;
+  margin-top: var(--space-md);
 }
 
 .list-item {
-  border: 1px solid var(--border);
-  background: #0f1a31;
-  border-radius: 12px;
-  padding: 10px 12px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-accent);
+  border-radius: var(--radius-md);
+  padding: var(--space-md) var(--space-lg);
   text-align: left;
 }
 
 .pathology-block {
-  border: 1px dashed var(--border);
-  border-radius: 12px;
-  padding: 12px;
-  background: #0f182d;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-lg);
+  background: var(--color-surface-muted);
 }
 
 .field-header {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-lg);
   flex-wrap: wrap;
-  margin-bottom: 8px;
+  margin-bottom: var(--space-sm);
 }
 
 .checklist-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 12px;
+  gap: var(--space-lg);
 }
 
 .checklist-group {
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 12px;
-  background: #0c1426;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-lg);
+  background: var(--color-surface-input);
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--space-md);
 }
 
 .checklist-heading {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  gap: 8px;
+  gap: var(--space-sm);
 }
 
 .checklist-title {
@@ -198,32 +191,32 @@ h3 {
 }
 
 .small {
-  font-size: 12px;
+  font-size: var(--font-size-xs);
 }
 
 .option-grid {
   display: grid;
-  gap: 8px;
+  gap: var(--space-sm);
 }
 
 .option {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 8px;
+  gap: var(--space-sm);
   align-items: start;
-  padding: 8px 10px;
-  border-radius: 10px;
-  border: 1px solid var(--border);
-  background: #0f1c32;
-  color: var(--text);
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-accent);
+  color: var(--color-text);
 }
 
 .option input {
-  margin-top: 4px;
+  margin-top: var(--space-xs);
 }
 
 .note-field {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-xs);
 }

--- a/mri-report-app/renderer/tokens.css
+++ b/mri-report-app/renderer/tokens.css
@@ -1,0 +1,36 @@
+:root {
+  /* Brand colors */
+  --color-bg: #0b1021;
+  --color-surface: #121a31;
+  --color-surface-muted: #0f182d;
+  --color-surface-accent: #0f1a31;
+  --color-surface-input: #0e1628;
+  --color-border: #1f2944;
+  --color-text: #e8ecf7;
+  --color-text-muted: #9fb2d2;
+  --color-accent: #3da9fc;
+  --color-accent-strong: #8ba9ff;
+
+  /* Elevation & radius */
+  --shadow-elevated: 0 20px 60px rgba(0, 0, 0, 0.35);
+  --radius-sm: 10px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+
+  /* Typography */
+  --font-base: "Inter", system-ui, -apple-system, sans-serif;
+  --font-size-xs: 12px;
+  --font-size-sm: 14px;
+  --font-size-md: 16px;
+  --font-size-lg: 18px;
+
+  /* Spacing */
+  --space-2xs: 4px;
+  --space-xs: 6px;
+  --space-sm: 8px;
+  --space-md: 10px;
+  --space-lg: 12px;
+  --space-xl: 16px;
+  --space-2xl: 20px;
+  --space-3xl: 24px;
+}

--- a/mri-report-app/scripts/build-storybook.js
+++ b/mri-report-app/scripts/build-storybook.js
@@ -1,0 +1,13 @@
+const fs = require("fs");
+const path = require("path");
+
+const source = path.join(__dirname, "..", "stories", "index.html");
+const targetDir = path.join(__dirname, "..", "storybook-static");
+const target = path.join(targetDir, "index.html");
+
+if (!fs.existsSync(targetDir)) {
+  fs.mkdirSync(targetDir, { recursive: true });
+}
+
+fs.copyFileSync(source, target);
+console.log(`Saved static catalog to ${target}`);

--- a/mri-report-app/scripts/storybook-server.js
+++ b/mri-report-app/scripts/storybook-server.js
@@ -1,0 +1,22 @@
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+
+const storyPath = path.join(__dirname, "..", "stories", "index.html");
+const port = process.env.PORT || 6006;
+
+const handler = (req, res) => {
+  if (req.url && req.url.startsWith("/renderer/")) {
+    const file = path.join(__dirname, "..", req.url);
+    fs.createReadStream(file).pipe(res);
+    return;
+  }
+
+  res.setHeader("Content-Type", "text/html");
+  fs.createReadStream(storyPath).pipe(res);
+};
+
+const server = http.createServer(handler);
+server.listen(port, () => {
+  console.log(`Storybook-lite running at http://localhost:${port}`);
+});

--- a/mri-report-app/scripts/vrt.js
+++ b/mri-report-app/scripts/vrt.js
@@ -1,0 +1,52 @@
+const fs = require("fs");
+const path = require("path");
+const puppeteer = require("puppeteer");
+const pixelmatch = require("pixelmatch");
+const { PNG } = require("pngjs");
+
+const buildDir = path.join(__dirname, "..", "storybook-static");
+const baselinePath = path.join(buildDir, "baseline.png");
+const currentPath = path.join(buildDir, "latest.png");
+const diffPath = path.join(buildDir, "diff.png");
+
+async function ensureStaticBuild() {
+  const exists = fs.existsSync(path.join(buildDir, "index.html"));
+  if (!exists) {
+    throw new Error("storybook-static/index.html not found. Run npm run build-storybook first.");
+  }
+}
+
+async function captureScreenshot() {
+  const browser = await puppeteer.launch({ headless: "new" });
+  const page = await browser.newPage();
+  await page.goto(`file://${path.join(buildDir, "index.html")}`);
+  await page.setViewport({ width: 1440, height: 900 });
+  await page.waitForSelector(".story-grid");
+  await page.screenshot({ path: currentPath, fullPage: true });
+  await browser.close();
+}
+
+function compareScreens() {
+  if (!fs.existsSync(baselinePath)) {
+    fs.copyFileSync(currentPath, baselinePath);
+    console.log("Baseline created for visual regression.");
+    return;
+  }
+
+  const img1 = PNG.sync.read(fs.readFileSync(baselinePath));
+  const img2 = PNG.sync.read(fs.readFileSync(currentPath));
+  const { width, height } = img1;
+  const diff = new PNG({ width, height });
+  const mismatch = pixelmatch(img1.data, img2.data, diff.data, width, height, { threshold: 0.1 });
+  fs.writeFileSync(diffPath, PNG.sync.write(diff));
+  console.log(`Pixel diff: ${mismatch}`);
+  if (mismatch > 0) {
+    throw new Error(`Visual regression detected. See ${diffPath}`);
+  }
+}
+
+(async () => {
+  await ensureStaticBuild();
+  await captureScreenshot();
+  compareScreens();
+})();

--- a/mri-report-app/stories/index.html
+++ b/mri-report-app/stories/index.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="tk">
+  <head>
+    <meta charset="UTF-8" />
+    <title>RSNA MRI UI Catalog</title>
+    <link rel="stylesheet" href="../renderer/tokens.css" />
+    <link rel="stylesheet" href="../renderer/styles.css" />
+    <style>
+      body {
+        padding: var(--space-3xl);
+      }
+      .story-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+        gap: var(--space-xl);
+      }
+    </style>
+  </head>
+  <body>
+    <h1>UI Catalog</h1>
+    <p class="muted">Static stories for key MRI report components.</p>
+    <div class="story-grid">
+      <section class="card">
+        <p class="eyebrow">Story</p>
+        <h2>Patient capture</h2>
+        <div class="grid">
+          <label>Familiýasy, ady<input type="text" required placeholder="Myrat Durdy" /></label>
+          <label>Doglan senesi<input type="date" value="1980-01-01" /></label>
+          <label>Jynsy
+            <select>
+              <option value="erkek">Erkek</option>
+              <option value="aýal">Aýal</option>
+            </select>
+          </label>
+          <label>Kart / ID<input type="text" placeholder="A-10234" /></label>
+        </div>
+        <div class="actions">
+          <button type="button" class="primary">Pacienti ýaz</button>
+          <p class="muted">Hasap görnüşi üçin demonstrasiýa</p>
+        </div>
+      </section>
+
+      <section class="card">
+        <p class="eyebrow">Story</p>
+        <h2>Pathology checklist</h2>
+        <div class="pathology-block">
+          <div class="field-header">
+            <span>Patologik üýtgemeler</span>
+            <p class="muted">Kategorýalar boýunça degişli wariantlary belläň.</p>
+          </div>
+          <div class="checklist-grid">
+            <div class="checklist-group">
+              <div class="checklist-heading">
+                <p class="checklist-title">Ishemiýa</p>
+                <p class="muted small">Multi-select</p>
+              </div>
+              <div class="option-grid">
+                <label class="option">
+                  <input type="checkbox" checked />
+                  <span>Ojak görnüşli üýtgeme ýok (Fazekas 0).</span>
+                </label>
+                <label class="option">
+                  <input type="checkbox" />
+                  <span>Subkortikal birnäçe gipersistens ojak.</span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add centralized design tokens and updated UI catalog for MRI report screens
- introduce telemetry hooks with RUM metrics and optional Sentry CDN bootstrap
- configure linting, basic unit tests, static Storybook-like catalog, and puppeteer-based visual regression script with CI workflow

## Testing
- `npm test -- --runInBand` *(fails: jest binary unavailable in environment package set)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bb4f2dbb88329a6ff2bc75a6786a9)