### PR TITLE
Implement autosave and reset for MRI report form

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -258,6 +258,12 @@ main {
   margin-bottom: 12px;
 }
 
+.section-tools {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .eyebrow {
   text-transform: uppercase;
   letter-spacing: 0.1em;


### PR DESCRIPTION
## Summary
- restore saved MRI report drafts from localStorage on load and autosave field changes and snippet selections
- add a reset control to clear all fields and saved drafts while keeping validation helpers
- update styling to accommodate the new control and enforce sensible date limits in the UI

## Testing
- Manual: Loaded the app in a local browser via `python3 -m http.server 8000` to verify draft restore, autosave, and reset interactions


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c466295d883298c91764db84524f2)