### PR TITLE
Use patient name in DOCX export filename

### DIFF
--- a/exportDocx.js
+++ b/exportDocx.js
@@ -3,6 +3,13 @@
 
 import { generatePlainTextReport } from "./report.js";
 
+function getPatientIdentifier(reportData) {
+  const rawName =
+    typeof reportData?.patientName === "string" ? reportData.patientName : "";
+  const normalized = rawName.trim();
+  return normalized || "hasabat";
+}
+
 function buildPatientHeader(blocks) {
   const patientBlock = blocks.find((block) => block.id === "patient");
   if (!patientBlock) return "";
@@ -57,7 +64,7 @@ export async function exportToDocx(reportData, blocks = []) {
   const blob = new Blob([html], { type: "application/msword" });
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
-  const filename = `rsna-mri-${reportData.patient_name || "hasabat"}.doc`;
+  const filename = `rsna-mri-${getPatientIdentifier(reportData)}.doc`;
   link.href = url;
   link.download = filename;
   document.body.appendChild(link);


### PR DESCRIPTION
## Summary
- add a helper to derive a safe patient identifier from report data
- update DOCX export filenames to pull from reportData.patientName

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cf5def2908329aafd04b6fe256798)