### PR TITLE
Generate blocks when exporting DOCX

### DIFF
--- a/exportDocx.js
+++ b/exportDocx.js
@@ -1,7 +1,7 @@
 // exportDocx.js
 // Ýönekeý Word (DOC) eksporty: hasabaty HTML görnüşinde ýygnap, .doc görnüşinde ýükleýär.
 
-import { generatePlainTextReport } from "./report.js";
+import { buildReportBlocks, generatePlainTextReport } from "./report.js";
 
 function buildPatientHeader(blocks) {
   const patientBlock = blocks.find((block) => block.id === "patient");
@@ -18,7 +18,7 @@ export async function exportToDocx(reportData, blocks = []) {
     return;
   }
 
-  const sectionBlocks = blocks.length > 0 ? blocks : [];
+  const sectionBlocks = blocks.length > 0 ? blocks : buildReportBlocks(reportData);
   const patientHeader = buildPatientHeader(sectionBlocks);
   const otherSections = sectionBlocks
     .filter((block) => block.id !== "patient")


### PR DESCRIPTION
## Summary
- use buildReportBlocks to generate section data when no blocks are provided to exportToDocx
- ensure patient headers and sections still render in DOC exports using generated data

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cf5c8a04883299be8e10621f5011a)