### PR TITLE
Handle snippet load failures with retry UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -265,11 +265,19 @@ async function renderSnippetSection() {
   grid.innerHTML = renderSnippetSkeleton();
   grid.setAttribute("aria-busy", "true");
 
-  const snippets = await loadSnippets();
-  grid.innerHTML = renderSnippetCards(snippets);
-  grid.removeAttribute("aria-busy");
-  bindSnippetInteractions();
-  applyStateToInputs();
+  loadSnippets()
+    .then((snippets) => {
+      grid.innerHTML = renderSnippetCards(snippets);
+      bindSnippetInteractions();
+      applyStateToInputs();
+    })
+    .catch((error) => {
+      console.error("Patologiýa wariantlaryny ýüklemek şowsuz boldy", error);
+      renderSnippetError(grid);
+    })
+    .finally(() => {
+      grid.removeAttribute("aria-busy");
+    });
 }
 
 function scheduleSnippetLoad() {
@@ -339,10 +347,29 @@ function renderSnippetCards(snippets) {
               </ul>
             </article>
           `,
-        )
-        .join("")}
+      )
+      .join("")}
     </div>
   `;
+}
+
+function renderSnippetError(grid) {
+  grid.innerHTML = `
+    <div class="notice error" role="alert">
+      <div>
+        <p class="eyebrow">Ýükleme ýalňyşy</p>
+        <p>Patologiýa wariantlaryny ýükläp bolmady. Internet birikmesini barlap, täzeden synanyşyň.</p>
+      </div>
+      <button id="retrySnippets" class="btn ghost">Täzeden synanyşyk</button>
+    </div>
+  `;
+
+  const retryButton = grid.querySelector("#retrySnippets");
+  if (retryButton) {
+    retryButton.addEventListener("click", () => {
+      renderSnippetSection();
+    });
+  }
 }
 
 function bindSnippetInteractions() {

--- a/styles.css
+++ b/styles.css
@@ -295,6 +295,26 @@ main {
   gap: 16px;
 }
 
+.notice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid #d6e3ff;
+  background: #f5f8ff;
+}
+
+.notice.error {
+  border-color: #ffd6d6;
+  background: #fff5f5;
+}
+
+.notice p {
+  margin: 4px 0;
+}
+
 .survey-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add error handling around snippet loading with a user-facing retry control
- style notice component for the snippet grid to surface loading errors

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cf87cd2248329bc34c91aeb9cba70)