### PR TITLE
Add VBA rewrite instructions for bookmark macros

### DIFF
--- a/VBA_REWRITE_GUIDE.md
+++ b/VBA_REWRITE_GUIDE.md
@@ -1,0 +1,30 @@
+# VBA rewrite instructions for bookmark-filling buttons
+
+The original VBA snippet defines five command buttons that insert MRI report snippets into bookmarked locations in a Word document. To rewrite the macro cleanly, follow these steps:
+
+1. **Extract bookmark writing into a helper**  
+   - Keep a single `SetBookmarkText` helper that accepts the bookmark name, replacement text, and document object.  
+   - Validate the bookmark exists before writing, and surface a meaningful message if it does not.
+
+2. **Isolate static phrases as constants**  
+   - Declare module-level `Const` strings for each canned phrase (e.g., demyelination finding, cerebellar tonsil position), so button handlers only assemble final text.
+
+3. **Normalize user input handling**  
+   - Wrap `InputBox` prompts into a utility that trims input, exits on cancel/empty, and enforces basic validation (e.g., numeric-only for sizes in centimeters).  
+   - When numeric values are required, format them with the desired decimal separator before insertion.
+
+4. **Refactor button click handlers**  
+   - Each `CommandButton*_Click` should call the shared helpers: gather input if needed, compose the text using constants, then call `SetBookmarkText`.  
+   - Example: prompt for cyst size once, build the sentence `"Dury germewde (septum pellucidum) süýri şekilli <size> sm kistasy anyklanýar."`, and write it to the `"dury"` bookmark.
+
+5. **Localize prompt and output strings together**  
+   - Store prompt titles, messages, and output templates in one place to keep Turkmen strings consistent and to simplify future translations.
+
+6. **Guard against repeated execution**  
+   - Optionally disable buttons after successful insertion or check whether a bookmark already contains text to avoid duplicate writes.
+
+7. **Document the macro behavior**  
+   - Add a header comment explaining the workflow: which bookmarks are populated, which prompts appear, and any validation rules.  
+   - Include short inline comments for any non-obvious string formatting or validation logic.
+
+Applying these steps will produce a clearer, maintainable macro that still fills the same bookmarks while handling user input safely and consistently.


### PR DESCRIPTION
## Summary
- add a concise guide for refactoring Word bookmark macros that fill MRI report text
- cover input validation, shared helpers, and localization considerations

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d030bd3748329af6c67c9a9c357c6)