### PR TITLE
Link VB form demo resources from homepage

### DIFF
--- a/app.js
+++ b/app.js
@@ -248,6 +248,49 @@ function renderShell() {
         </div>
       </div>
     </section>
+
+    <section class="card resource-card" id="vbDemoSection">
+      <div class="section-header">
+        <div>
+          <p class="eyebrow">Goşmaça demo</p>
+          <h2>vb-form-demo papkasyndaky dokumentler</h2>
+          <p class="muted">Absolýut pozisiýaly web-forma bilen baglanyşykly faýllar baş sahypadan hem elýeterli.</p>
+        </div>
+        <div class="pill">VB görnüşi</div>
+      </div>
+      <div class="resource-grid">
+        <div class="resource-copy">
+          <p>
+            Formanyň ähli kontrol blueprintleri, ýagdaý dumpy we WinForms görnüşindäki bezegleri aýratyn papkada saklanýar.
+            Faýllary aşakdaky baglanyşyklar arkaly göni açyp bilersiňiz.
+          </p>
+          <p class="muted">Demo sahypasynda maglumatlary giriziň we «Показать данные» arkaly JSON görnüşinde serediň.</p>
+        </div>
+        <ul class="resource-links" aria-label="VB forma demo faýllary">
+          <li>
+            <a class="resource-link" href="vb-form-demo/index.html" target="_blank" rel="noopener">
+              Demo sahypasy (index.html)
+              <span aria-hidden="true">→</span>
+            </a>
+            <p class="muted">Absolýut pozisiýaly forma we maglumatlaryň ýaşaýyş ýagdaýda çykarylyşy.</p>
+          </li>
+          <li>
+            <a class="resource-link" href="vb-form-demo/app.js" target="_blank" rel="noopener">
+              app.js
+              <span aria-hidden="true">→</span>
+            </a>
+            <p class="muted">Kontrol blueprintleri, ýagdaý obýekti we JSON dump düwmesi.</p>
+          </li>
+          <li>
+            <a class="resource-link" href="vb-form-demo/styles.css" target="_blank" rel="noopener">
+              styles.css
+              <span aria-hidden="true">→</span>
+            </a>
+            <p class="muted">WinForms/VB görnüşindäki stil we pozisiýalar.</p>
+          </li>
+        </ul>
+      </div>
+    </section>
   `;
 }
 

--- a/index.html
+++ b/index.html
@@ -206,6 +206,7 @@
         <li><a href="#snippetSection">Patologiýa wariantlary</a></li>
         <li><a href="#previewSection">Netije</a></li>
         <li><a href="#storageSection">Ammar</a></li>
+        <li><a href="#vbDemoSection">VB forma demo</a></li>
       </ul>
     </nav>
     <div class="badge" aria-label="SQL.js ýatda saklaýyş + Word eksporty">SQL.js ýatda saklaýyş + Word eksporty</div>

--- a/styles.css
+++ b/styles.css
@@ -704,6 +704,51 @@ input[type="checkbox"]:focus-visible {
   font-weight: 700;
 }
 
+.resource-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+  align-items: start;
+}
+
+.resource-links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.resource-links li {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  background: #f8fafc;
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.05);
+}
+
+.resource-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  color: var(--text);
+  text-decoration: none;
+}
+
+.resource-link:hover,
+.resource-link:focus-visible {
+  color: var(--accent-strong);
+  outline: none;
+}
+
+.resource-copy {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.05), rgba(16, 185, 129, 0.05));
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,


### PR DESCRIPTION
## Summary
- add a navigation entry and resource card that links to the vb-form-demo assets from the main page
- surface direct links to the demo HTML, JS, and CSS files with supporting copy
- style the new resource list to match existing cards

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d09ed76648329b4fb4277db6dcf61)